### PR TITLE
Implement per-plan role mappings feature

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/acl.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/acl.php
@@ -295,11 +295,6 @@ function memberful_can_user_access_post( $user, $post ) {
     return $user ? true : false;
   }
 
-  // Grant access if user has a subscription and post or one of its terms allows access with any subscription
-  if ( memberful_wp_post_viewable_by_any_subscriber( $post, $terms_for_post )) {
-    return !empty( $user_subs );
-  }
-
   // Get the set of restrictions for this post
   $post_acl = get_post_meta( $post, 'memberful_acl', TRUE );
   $plans_for_post = isset( $post_acl['subscription'] ) ? $post_acl['subscription'] : array();
@@ -331,7 +326,12 @@ function memberful_can_user_access_post( $user, $post ) {
   $user_products = $user ? array_keys( memberful_wp_user_products( $user )) : array();
   $product_intersect = array_intersect( $products_for_post, $user_products );
 
+  // If there are no specific plan/product restrictions, fall back to the broad rules
   if (( empty( $plans_for_post ) ) && ( empty( $products_for_post ))) {
+    // Grant access if user has a subscription and post or one of its terms allows access with any subscription
+    if ( memberful_wp_post_viewable_by_any_subscriber( $post, $terms_for_post )) {
+      return !empty( $user_subs );
+    }
     // Grant access if no restrictions
     return true;
   } elseif ( ! empty( $plan_intersect ) || ! empty( $product_intersect )) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -380,6 +380,15 @@ function memberful_wp_advanced_settings() {
   $current_mappings      = memberful_wp_get_all_plan_role_mappings();
   $use_per_plan_roles    = memberful_wp_use_per_plan_roles();
 
+  /**
+   * Filter to determine if user roles should be automatically updated/synced to existing users on save.
+   *
+   * @since 1.77.0
+   *
+   * @param bool $should_update_user_roles Whether to update user roles. (Default: true)
+   */
+  $should_update_user_roles = apply_filters( 'memberful_should_bulk_update_user_roles_on_save', true );
+
   if ( ! empty( $_POST ) ) {
     if ( isset( $_POST['role_mappings']['active_customer'] ) && array_key_exists( $_POST['role_mappings']['active_customer'], $allowed_roles ) ) {
       $new_active_role = sanitize_text_field($_POST['role_mappings']['active_customer']);
@@ -394,8 +403,9 @@ function memberful_wp_advanced_settings() {
       update_option( 'memberful_role_active_customer', $new_active_role );
       update_option( 'memberful_role_inactive_customer', $new_inactive_role );
 
-      // TODO: Update all users with the new active/inactive role mappings.
-      // memberful_wp_update_customer_roles( $current_active_role, $new_active_role, $current_inactive_role, $new_inactive_role );
+      if ( $should_update_user_roles ) {
+        memberful_wp_update_customer_roles( $current_active_role, $new_active_role, $current_inactive_role, $new_inactive_role );
+      }
 
       Memberful_Wp_Reporting::report( __('Active/Inactive role settings updated') );
     } else {
@@ -431,8 +441,9 @@ function memberful_wp_advanced_settings() {
 
       update_option( 'memberful_plan_role_mappings', $new_plan_mappings );
 
-      // TODO: Update all users with the new plan role mappings.
-      // memberful_wp_update_all_user_roles_with_plan_mappings();
+      if ( $should_update_user_roles ) {
+        memberful_wp_update_all_user_roles_with_plan_mappings();
+      }
 
       Memberful_Wp_Reporting::report( __('Per-plan role mappings updated') );
     } else {

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -431,10 +431,6 @@ function memberful_wp_advanced_settings() {
 
       update_option( 'memberful_plan_role_mappings', $new_plan_mappings );
 
-      // Reset the previously saved active/inactive role mappings.
-      update_option( 'memberful_role_active_customer', '' );
-      update_option( 'memberful_role_inactive_customer', '' );
-
       // TODO: Update all users with the new plan role mappings.
       // memberful_wp_update_all_user_roles_with_plan_mappings();
 
@@ -700,58 +696,4 @@ function memberful_wp_global_marketing() {
       'form_target' => memberful_wp_plugin_global_marketing_url()
     )
   );
-}
-
-function memberful_wp_plan_role_mappings() {
-  $allowed_roles = memberful_wp_roles_that_can_be_mapped_to();
-  $subscription_plans = memberful_subscription_plans();
-  $current_mappings = memberful_wp_get_all_plan_role_mappings();
-  $use_per_plan_roles = memberful_wp_use_per_plan_roles();
-
-  if ( ! empty( $_POST ) && isset( $_POST['save_plan_role_mappings'] ) ) {
-    if ( ! memberful_wp_valid_nonce( 'memberful_options' ) ) {
-      return;
-    }
-
-    // Update the per-plan roles setting
-    $use_per_plan_roles = isset( $_POST['use_per_plan_roles'] );
-    memberful_wp_set_use_per_plan_roles( $use_per_plan_roles );
-
-    if ( $use_per_plan_roles && isset( $_POST['plan_role_mappings'] ) ) {
-      $new_mappings = array();
-
-      foreach ( $_POST['plan_role_mappings'] as $plan_id => $role ) {
-        $plan_id = intval( $plan_id );
-        $role = sanitize_text_field( $role );
-
-        // Only save if the role is valid and the plan exists
-        if ( ! empty( $role ) && array_key_exists( $role, $allowed_roles ) && isset( $subscription_plans[ $plan_id ] ) ) {
-          $new_mappings[ $plan_id ] = $role;
-        }
-      }
-
-      update_option( 'memberful_plan_role_mappings', $new_mappings );
-
-      // Update all existing users with the new role mappings
-      memberful_wp_update_all_user_roles_with_plan_mappings();
-
-      Memberful_Wp_Reporting::report( __( 'Plan role mappings updated successfully', 'memberful' ) );
-    } else {
-      // Clear all mappings if per-plan roles are disabled
-      update_option( 'memberful_plan_role_mappings', array() );
-      Memberful_Wp_Reporting::report( __( 'Per-plan roles disabled', 'memberful' ) );
-    }
-
-    wp_redirect( memberful_wp_plugin_plan_role_mappings_url() );
-    return;
-  }
-
-  $vars = array(
-    'subscription_plans' => $subscription_plans,
-    'available_roles' => $allowed_roles,
-    'current_mappings' => $current_mappings,
-    'use_per_plan_roles' => $use_per_plan_roles,
-  );
-
-  memberful_wp_render( 'plan_role_mappings', $vars );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -394,7 +394,8 @@ function memberful_wp_advanced_settings() {
       update_option( 'memberful_role_active_customer', $new_active_role );
       update_option( 'memberful_role_inactive_customer', $new_inactive_role );
 
-      memberful_wp_update_customer_roles( $current_active_role, $new_active_role, $current_inactive_role, $new_inactive_role );
+      // TODO: Update all users with the new active/inactive role mappings.
+      // memberful_wp_update_customer_roles( $current_active_role, $new_active_role, $current_inactive_role, $new_inactive_role );
 
       Memberful_Wp_Reporting::report( __('Active/Inactive role settings updated') );
     } else {
@@ -410,8 +411,17 @@ function memberful_wp_advanced_settings() {
 
       if ( isset( $_POST['plan_role_mappings'] ) && is_array( $_POST['plan_role_mappings'] ) ) {
         foreach ( $_POST['plan_role_mappings'] as $plan_id => $role ) {
-          $plan_id = intval( $plan_id );
+          if ( empty( $plan_id ) ) {
+            continue;
+          }
+
+          $plan_id = is_numeric( $plan_id ) ? intval( $plan_id ) : sanitize_text_field( $plan_id );
           $role    = sanitize_text_field( $role );
+
+          if ( 'inactive' === $plan_id ) {
+            $new_plan_mappings['inactive'] = $role;
+            continue;
+          }
 
           if ( ! empty( $role ) && array_key_exists( $role, $allowed_roles ) && isset( $subscription_plans[ $plan_id ] ) ) {
             $new_plan_mappings[ $plan_id ] = $role;
@@ -420,7 +430,10 @@ function memberful_wp_advanced_settings() {
       }
 
       update_option( 'memberful_plan_role_mappings', $new_plan_mappings );
-      memberful_wp_update_all_user_roles_with_plan_mappings();
+
+      // TODO: Update all users with the new plan role mappings.
+      // memberful_wp_update_all_user_roles_with_plan_mappings();
+
       Memberful_Wp_Reporting::report( __('Per-plan role mappings updated') );
     } else {
       // If disabling, clear mappings
@@ -702,22 +715,22 @@ function memberful_wp_plan_role_mappings() {
 
     if ( $use_per_plan_roles && isset( $_POST['plan_role_mappings'] ) ) {
       $new_mappings = array();
-      
+
       foreach ( $_POST['plan_role_mappings'] as $plan_id => $role ) {
         $plan_id = intval( $plan_id );
         $role = sanitize_text_field( $role );
-        
+
         // Only save if the role is valid and the plan exists
         if ( ! empty( $role ) && array_key_exists( $role, $allowed_roles ) && isset( $subscription_plans[ $plan_id ] ) ) {
           $new_mappings[ $plan_id ] = $role;
         }
       }
-      
+
       update_option( 'memberful_plan_role_mappings', $new_mappings );
-      
+
       // Update all existing users with the new role mappings
       memberful_wp_update_all_user_roles_with_plan_mappings();
-      
+
       Memberful_Wp_Reporting::report( __( 'Plan role mappings updated successfully', 'memberful' ) );
     } else {
       // Clear all mappings if per-plan roles are disabled

--- a/wordpress/wp-content/plugins/memberful-wp/src/admin.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/admin.php
@@ -431,6 +431,10 @@ function memberful_wp_advanced_settings() {
 
       update_option( 'memberful_plan_role_mappings', $new_plan_mappings );
 
+      // Reset the previously saved active/inactive role mappings.
+      update_option( 'memberful_role_active_customer', '' );
+      update_option( 'memberful_role_inactive_customer', '' );
+
       // TODO: Update all users with the new plan role mappings.
       // memberful_wp_update_all_user_roles_with_plan_mappings();
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/authenticator.php
@@ -19,7 +19,7 @@ class Memberful_Authenticator {
    */
   static public function audit_password_reset( $allowed, $user_id ) {
     $user = new WP_User( $user_id );
-    $member_role = memberful_wp_role_for_active_customer();
+    $member_role = memberful_wp_user_role_for_user( $user );
 
     return $user->has_cap( $member_role ) ? FALSE : $allowed;
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metabox.php
@@ -116,6 +116,10 @@ function memberful_wp_save_postdata( $post_id ) {
   memberful_wp_set_post_available_to_any_registered_users( $post_id, $viewable_by_any_registered_users );
 
   $viewable_by_anybody_subscribed_to_a_plan = isset($_POST['memberful_viewable_by_anybody_subscribed_to_a_plan']) && $_POST['memberful_viewable_by_anybody_subscribed_to_a_plan'] === '1';
+  // Enforce mutual exclusivity at save time: if specific plans are chosen, do not allow broad access
+  if ( !empty($subscription_plan_ids) ) {
+    $viewable_by_anybody_subscribed_to_a_plan = false;
+  }
   memberful_wp_set_post_available_to_anybody_subscribed_to_a_plan( $post_id, $viewable_by_anybody_subscribed_to_a_plan );
 
   if(!isset($_POST['memberful_marketing_content']))

--- a/wordpress/wp-content/plugins/memberful-wp/src/options.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/options.php
@@ -16,6 +16,8 @@ function memberful_wp_all_options() {
     'memberful_error_log' => array(),
     'memberful_role_active_customer' => 'subscriber',
     'memberful_role_inactive_customer' => 'subscriber',
+    'memberful_plan_role_mappings' => array(),
+    'memberful_use_per_plan_roles' => FALSE,
     'memberful_posts_available_to_any_registered_user' => array(),
     'memberful_hide_admin_toolbar' => TRUE,
     'memberful_block_dashboard_access' => TRUE,

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -147,8 +147,7 @@ function memberful_wp_user_role_for_user( WP_User $user ) {
 
   $role_decision = Memberful_Wp_User_Role_Decision::build();
 
-  $current_role = ! empty( $user->roles ) ? reset( $user->roles ) : get_option( 'default_role', 'subscriber' );
-  $user_role = $role_decision->role_for_user( $current_role, memberful_wp_user_plans_subscribed_to( $user->ID ) );
+  $user_role = $role_decision->role_for_user( memberful_wp_user_plans_subscribed_to( $user->ID ) );
 
   /**
    * Filter to determine the user role for a user.

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -142,12 +142,13 @@ function memberful_wp_update_all_user_roles_with_plan_mappings() {
  */
 function memberful_wp_user_role_for_user( WP_User $user ) {
   if ( ! $user instanceof WP_User ) {
-    return '';
+    return get_option( 'default_role', 'subscriber' );
   }
 
   $role_decision = Memberful_Wp_User_Role_Decision::build();
 
-  $user_role = $role_decision->role_for_user( reset( $user->roles ), memberful_wp_user_plans_subscribed_to( $user->ID ) );
+  $current_role = ! empty( $user->roles ) ? reset( $user->roles ) : get_option( 'default_role', 'subscriber' );
+  $user_role = $role_decision->role_for_user( $current_role, memberful_wp_user_plans_subscribed_to( $user->ID ) );
 
   /**
    * Filter to determine the user role for a user.

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -21,11 +21,21 @@ function memberful_wp_roles_that_can_be_mapped_to() {
 }
 
 function memberful_wp_role_for_active_customer( $default_role = 'subscriber' ) {
-  return get_option( 'memberful_role_active_customer', $default_role );
+  $configured_role = get_option( 'memberful_role_active_customer', $default_role );
+
+  if ( array_key_exists( $configured_role, memberful_wp_roles_that_can_be_mapped_to() ) )
+    return $configured_role;
+
+  return $default_role;
 }
 
 function memberful_wp_role_for_inactive_customer( $default_role = 'subscriber' ) {
-  return get_option( 'memberful_role_inactive_customer', $default_role );
+  $configured_role = get_option( 'memberful_role_inactive_customer', $default_role );
+
+  if ( array_key_exists( $configured_role, memberful_wp_roles_that_can_be_mapped_to() ) )
+    return $configured_role;
+
+  return $default_role;
 }
 
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -7,7 +7,15 @@ function memberful_wp_roles_that_can_be_mapped_to() {
 
   unset($allowed_roles['administrator']);
 
-  $allowed_roles = apply_filters( 'memberful_roles_for_mapping', $allowed_roles );
+  /**
+   * Filter to determine the allowed roles that can be mapped to.
+   *
+   * @since 1.77.0
+   *
+   * @param array $allowed_roles The allowed roles that can be mapped to.
+   * @return array The allowed roles that can be mapped to.
+   */
+  $allowed_roles = apply_filters( 'memberful_allowed_roles_for_mapping', $allowed_roles );
 
   return $allowed_roles;
 }
@@ -69,6 +77,15 @@ function memberful_wp_remove_plan_role_mapping( $plan_id ) {
  */
 function memberful_wp_get_all_plan_role_mappings() {
   $mappings = get_option( 'memberful_plan_role_mappings', array() );
+
+  /**
+   * Filter to get all the saved per-plan role mappings.
+   *
+   * @since 1.77.0
+   *
+   * @param array $mappings The saved per-plan role mappings.
+   * @return array The role mappings.
+   */
   return apply_filters( 'memberful_all_plan_role_mappings', $mappings );
 }
 
@@ -78,6 +95,15 @@ function memberful_wp_get_all_plan_role_mappings() {
  */
 function memberful_wp_use_per_plan_roles() {
   $use_per_plan_roles = get_option( 'memberful_use_per_plan_roles', FALSE );
+
+  /**
+   * Filter to determine if per-plan roles are enabled.
+   *
+   * @since 1.77.0
+   *
+   * @param bool $use_per_plan_roles Whether per-plan roles are enabled.
+   * @return bool Whether per-plan roles are enabled. (Default: false)
+   */
   return apply_filters( 'memberful_use_per_plan_roles', $use_per_plan_roles );
 }
 
@@ -120,5 +146,17 @@ function memberful_wp_user_role_for_user( WP_User $user ) {
   }
 
   $role_decision = Memberful_Wp_User_Role_Decision::build();
-  return $role_decision->role_for_user( reset( $user->roles ), memberful_wp_user_plans_subscribed_to( $user->ID ) );
+
+  $user_role = $role_decision->role_for_user( reset( $user->roles ), memberful_wp_user_plans_subscribed_to( $user->ID ) );
+
+  /**
+   * Filter to determine the user role for a user.
+   *
+   * @since 1.77.0
+   *
+   * @param string $user_role The user role for the user.
+   * @param WP_User $user The user.
+   * @return string The user role for the user.
+   */
+  return apply_filters( 'memberful_wp_user_role_for_user', $user_role, $user );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -116,7 +116,7 @@ function memberful_wp_update_all_user_roles_with_plan_mappings() {
  */
 function memberful_wp_user_role_for_user( WP_User $user ) {
   if ( ! $user instanceof WP_User ) {
-    return new WP_Error( 'invalid_user', __( 'Invalid user', 'memberful' ) );
+    return '';
   }
 
   $role_decision = Memberful_Wp_User_Role_Decision::build();

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -39,3 +39,75 @@ function memberful_wp_update_customer_roles( $old_active_role, $new_active_role,
     $role_decision->update_user_role( $user );
   }
 }
+
+/**
+ * Get the role mapping for a specific plan
+ * @param int $plan_id The plan ID
+ * @return string The WordPress role for this plan, or null if not mapped
+ */
+function memberful_wp_get_plan_role_mapping( $plan_id ) {
+  $mappings = get_option( 'memberful_plan_role_mappings', array() );
+  return isset( $mappings[ $plan_id ] ) ? $mappings[ $plan_id ] : null;
+}
+
+/**
+ * Set the role mapping for a specific plan
+ * @param int $plan_id The plan ID
+ * @param string $role The WordPress role to assign
+ */
+function memberful_wp_set_plan_role_mapping( $plan_id, $role ) {
+  $mappings = get_option( 'memberful_plan_role_mappings', array() );
+  $mappings[ $plan_id ] = $role;
+  update_option( 'memberful_plan_role_mappings', $mappings );
+}
+
+/**
+ * Remove the role mapping for a specific plan
+ * @param int $plan_id The plan ID
+ */
+function memberful_wp_remove_plan_role_mapping( $plan_id ) {
+  $mappings = get_option( 'memberful_plan_role_mappings', array() );
+  unset( $mappings[ $plan_id ] );
+  update_option( 'memberful_plan_role_mappings', $mappings );
+}
+
+/**
+ * Get all plan role mappings
+ * @return array Array of plan_id => role mappings
+ */
+function memberful_wp_get_all_plan_role_mappings() {
+  return get_option( 'memberful_plan_role_mappings', array() );
+}
+
+/**
+ * Check if per-plan roles are enabled
+ * @return bool
+ */
+function memberful_wp_use_per_plan_roles() {
+  return get_option( 'memberful_use_per_plan_roles', FALSE );
+}
+
+/**
+ * Enable or disable per-plan roles
+ * @param bool $enabled
+ */
+function memberful_wp_set_use_per_plan_roles( $enabled ) {
+  update_option( 'memberful_use_per_plan_roles', $enabled );
+}
+
+/**
+ * Update all existing users with the new plan role mappings
+ */
+function memberful_wp_update_all_user_roles_with_plan_mappings() {
+  $mapped_users = Memberful_User_Mapping_Repository::fetch_user_ids_of_all_mapped_members();
+  
+  if ( empty( $mapped_users ) ) {
+    return;
+  }
+
+  $users = get_users( array( 'fields' => 'all', 'include' => $mapped_users ) );
+
+  foreach ( $users as $user ) {
+    Memberful_Wp_User_Role_Decision::ensure_user_role_is_correct( $user );
+  }
+}

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -13,15 +13,11 @@ function memberful_wp_roles_that_can_be_mapped_to() {
 }
 
 function memberful_wp_role_for_active_customer( $default_role = 'subscriber' ) {
-  $role_decision = Memberful_Wp_User_Role_Decision::build(array($default_role));
-
-  return $role_decision->role_for_user( $default_role, array() );
+  return get_option( 'memberful_role_active_customer', $default_role );
 }
 
 function memberful_wp_role_for_inactive_customer( $default_role = 'subscriber' ) {
-  $role_decision = Memberful_Wp_User_Role_Decision::build(array($default_role));
-
-  return $role_decision->get_inactive_role();
+  return get_option( 'memberful_role_inactive_customer', $default_role );
 }
 
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/roles.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/roles.php
@@ -78,6 +78,18 @@ function memberful_wp_remove_plan_role_mapping( $plan_id ) {
 function memberful_wp_get_all_plan_role_mappings() {
   $mappings = get_option( 'memberful_plan_role_mappings', array() );
 
+  if ( ! is_array( $mappings ) ) {
+    $mappings = array();
+  }
+
+  $allowed_roles = memberful_wp_roles_that_can_be_mapped_to();
+
+  foreach ( $mappings as $plan_id => $role ) {
+    if ( empty( $role ) || ! array_key_exists( $role, $allowed_roles ) ) {
+      $mappings[ $plan_id ] = get_option( 'default_role', 'subscriber' );
+    }
+  }
+
   /**
    * Filter to get all the saved per-plan role mappings.
    *

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -100,6 +100,10 @@ function memberful_wp_plugin_protect_bbpress_url($no_header = FALSE) {
   return memberful_wp_plugin_settings_url($no_header, 'protect_bbpress');
 }
 
+function memberful_wp_plugin_plan_role_mappings_url($no_header = FALSE) {
+  return memberful_wp_plugin_settings_url($no_header, 'plan_role_mappings');
+}
+
 /**
  * Generate a URL to the Memberful site
  *

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
@@ -101,8 +101,8 @@ class Memberful_Wp_User_Role_Decision {
     if ( memberful_wp_use_per_plan_roles() ) {
       $plan_mappings = memberful_wp_get_all_plan_role_mappings();
 
-      if ( isset( $plan_mappings['inactive'] ) ) {
-        return $plan_mappings['inactive'] ?? $default_inactive_role;
+      if ( isset( $plan_mappings['inactive'] ) && ! empty( $plan_mappings['inactive'] ) ) {
+        return $plan_mappings['inactive'];
       }
     }
 

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
@@ -51,14 +51,14 @@ class Memberful_Wp_User_Role_Decision {
 
   public function update_user_role( WP_User $user ) {
     $current_subscriptions = memberful_wp_user_plans_subscribed_to( $user->ID );
-    $new_role = $this->role_for_user( reset( $user->roles ), $current_subscriptions );
+    $new_role = $this->role_for_user( $current_subscriptions );
 
     $new_role = apply_filters( 'memberful_user_role_for_update_user_role', $new_role, $user, $current_subscriptions );
 
     $user->set_role( $new_role );
   }
 
-  public function role_for_user($current_role, $current_subscriptions) {
+  public function role_for_user($current_subscriptions) {
 
     /**
      * Filter to determine the current subscriptions for a user.
@@ -171,7 +171,7 @@ class Memberful_Wp_User_Role_Decision {
         if ($role && $role->capabilities) {
           // Get the level_* capabilities and find the highest one that is set to true.
           $level_capabilities = array_filter($role->capabilities, function($value, $key) {
-            return str_starts_with($key, 'level_') && $value === true;
+            return strpos($key, 'level_') === 0 && $value === true;
           }, ARRAY_FILTER_USE_BOTH);
 
           if (empty($level_capabilities)) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
@@ -188,6 +188,13 @@ class Memberful_Wp_User_Role_Decision {
         }
     }
 
+    if ( empty( $highest_role ) && ! empty( $roles ) ) {
+      // Fallback to the first role in the list if no highest role is found.
+      // This can happen if the user has no roles with level_* capabilities,
+      // or with custom roles that don't have level_* capabilities.
+      $highest_role = reset( $roles );
+    }
+
     return $highest_role;
   }
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
@@ -31,10 +31,10 @@ class Memberful_Wp_User_Role_Decision {
   }
 
   public function update_user_role( WP_User $user ) {
-    $new_role = $this->role_for_user(
-      reset( $user->roles ),
-      memberful_wp_user_plans_subscribed_to( $user->ID )
-    );
+    $current_subscriptions = memberful_wp_user_plans_subscribed_to( $user->ID );
+    $new_role = $this->role_for_user( reset( $user->roles ), $current_subscriptions );
+
+    $new_role = apply_filters( 'memberful_wp_user_role_for_update_user_role', $new_role, $user, $current_subscriptions );
 
     $user->set_role( $new_role );
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/user/role_decision.php
@@ -42,10 +42,6 @@ class Memberful_Wp_User_Role_Decision {
   public function role_for_user($current_role, $current_subscriptions) {
     $is_active = ! empty( $current_subscriptions );
 
-    if ( ! in_array( $current_role, $this->roles_memberful_is_allowed_to_change_from ) ) {
-      return $current_role;
-    }
-
     // If per-plan roles are enabled and the user has an active subscription,
     // use the role mapping for the user's subscriptions.
     if ( memberful_wp_use_per_plan_roles() && $is_active ) {
@@ -104,6 +100,8 @@ class Memberful_Wp_User_Role_Decision {
       if ( isset( $plan_mappings['inactive'] ) && ! empty( $plan_mappings['inactive'] ) ) {
         return $plan_mappings['inactive'];
       }
+
+      return get_option( 'default_role', 'subscriber' );
     }
 
     return $default_inactive_role;

--- a/wordpress/wp-content/plugins/memberful-wp/views/acl_selection.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/acl_selection.php
@@ -23,7 +23,7 @@
             <?php foreach($subscriptions as $id => $subscription): ?>
               <li>
                 <label>
-                  <input type="checkbox" name="memberful_subscription_acl[]" value="<?php echo esc_attr($id); ?>" <?php checked( $subscription['checked'] ); ?>>
+                  <input type="checkbox" class="memberful-subscription-plan" name="memberful_subscription_acl[]" value="<?php echo esc_attr($id); ?>" <?php checked( $subscription['checked'] ); ?>>
                   <?php echo esc_html( $subscription['name'] ); ?>
                 </label>
               </li>
@@ -48,3 +48,40 @@
         <?php endif; ?>
       </div>
     </div>
+    <script type="text/javascript">
+    jQuery(function($){
+      var anyActive = $('input[name="memberful_viewable_by_anybody_subscribed_to_a_plan"]');
+      var specific  = $('input.memberful-subscription-plan');
+
+      function syncFromAnyActive(){
+        var isOn = anyActive.is(':checked');
+        if (isOn) {
+          if (specific.filter(':checked').length) {
+            specific.filter(':checked').prop('checked', false).trigger('change');
+          }
+          specific.prop('disabled', true);
+        } else {
+          specific.prop('disabled', false);
+        }
+      }
+
+      function syncFromSpecific(){
+        if (specific.filter(':checked').length > 0) {
+          if (anyActive.is(':checked')) {
+            anyActive.prop('checked', false).trigger('change');
+          }
+        }
+      }
+
+      anyActive.on('change', function(){
+        syncFromAnyActive();
+      });
+
+      specific.on('change', function(){
+        syncFromSpecific();
+      });
+
+      // Initial state
+      syncFromAnyActive();
+    });
+    </script>

--- a/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
@@ -28,7 +28,7 @@
 
       <h2 style="margin-top:20px;">Per-Plan Roles</h2>
       <p><?php _e( 'Assign specific WordPress roles to specific subscription plans. Enable this to override the simple active/inactive role mapping.', 'memberful' ); ?></p>
-      <p><?php _e( 'Learn more about roles <a href="https://memberful.com/docs/" target="_blank">here</a>.', 'memberful' ); ?></p>
+      <p><?php _e( 'Learn more about per-plan roles <a href="https://memberful.com/docs/" target="_blank">here</a>.', 'memberful' ); ?></p>
 
       <table class="form-table">
         <tr>

--- a/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
@@ -1,7 +1,7 @@
 <div class="wrap">
   <?php memberful_wp_render('option_tabs', array('active' => 'advanced_settings')); ?>
   <?php memberful_wp_render('flash'); ?>
-  <p><?php _e( "Assign roles to active (paying) and inactive (not paying) members. Memberful will automatically keep the role mappings in sync. Works best with custom roles created by other plugins.", 'memberful' ); ?></p>
+  <p class="memberful-role-mapping-table-description"><?php _e( "Assign roles to active (paying) and inactive (not paying) members. Memberful will automatically keep the role mappings in sync. Works best with custom roles created by other plugins.", 'memberful' ); ?></p>
   <form method="post" action="<?php echo esc_url(memberful_wp_plugin_advanced_settings_url( TRUE )); ?>">
       <table class="widefat fixed" id="memberful-role-mapping-table">
         <thead>
@@ -25,7 +25,73 @@
           <?php endforeach; ?>
         </tbody>
       </table>
+
+      <h2 style="margin-top:20px;">Per-Plan Roles</h2>
+      <p><?php _e( 'Assign specific WordPress roles to specific subscription plans. Enable this to override the simple active/inactive role mapping.', 'memberful' ); ?></p>
+
+      <table class="form-table">
+        <tr>
+          <th scope="row">
+            <label for="use_per_plan_roles"><?php _e( 'Enable Per-Plan Roles', 'memberful' ); ?></label>
+          </th>
+          <td>
+            <input type="checkbox" id="use_per_plan_roles" name="use_per_plan_roles" value="1" <?php checked( $use_per_plan_roles ); ?> />
+          </td>
+        </tr>
+      </table>
+
+      <div id="plan-role-mappings" style="<?php echo $use_per_plan_roles ? '' : 'display: none;'; ?>">
+        <?php if ( empty( $subscription_plans ) ): ?>
+          <p class="description"><?php _e( 'No subscription plans found. Please sync your plans from Memberful first.', 'memberful' ); ?></p>
+        <?php else: ?>
+          <table class="widefat fixed" id="memberful-plan-role-mapping-table">
+            <thead>
+              <tr>
+                <th scope="col" class="manage-column"><?php _e( 'Subscription Plan', 'memberful' ); ?></th>
+                <th scope="col" class="manage-column"><?php _e( 'WordPress Role', 'memberful' ); ?></th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach( $subscription_plans as $plan_id => $plan ): ?>
+              <tr>
+                <td class="plan-name">
+                  <strong><?php echo esc_html( $plan['name'] ); ?></strong>
+                  <?php if ( ! empty( $plan['description'] ) ): ?>
+                  <br>
+                  <small><?php echo esc_html( $plan['description'] ); ?></small>
+                  <?php endif; ?>
+                </td>
+                <td class="mapped-role">
+                  <select name="plan_role_mappings[<?php echo esc_attr( $plan_id ); ?>]">
+                    <option value=""><?php _e( 'No specific role (use default)', 'memberful' ); ?></option>
+                    <?php foreach( $available_roles as $role => $role_name ): ?>
+                    <option value="<?php echo esc_attr( $role ); ?>" <?php echo ( isset($current_mappings[$plan_id]) && $current_mappings[$plan_id] === $role ) ? 'selected="selected"' : '' ?>>
+                      <?php echo esc_html( $role_name ); ?>
+                    </option>
+                    <?php endforeach; ?>
+                  </select>
+                </td>
+              </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        <?php endif; ?>
+      </div>
+
       <p class="button-controls"><input type="submit" name="nav-menu-locations" id="nav-menu-locations" class="button button-primary left" value="Save Changes"></p>
       <?php memberful_wp_nonce_field( 'memberful_options' ); ?>
     </form>
+  <script type="text/javascript">
+  jQuery(document).ready(function($) {
+    function togglePerPlanUI() {
+      var enabled = $('#use_per_plan_roles').is(':checked');
+      $('#plan-role-mappings').toggle(enabled);
+      $('#memberful-role-mapping-table').toggle(!enabled);
+      $('.memberful-role-mapping-table-description').toggle(!enabled);
+    }
+
+    $('#use_per_plan_roles').on('change', togglePerPlanUI);
+    togglePerPlanUI();
+  });
+  </script>
 </div>

--- a/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/advanced_settings.php
@@ -28,6 +28,7 @@
 
       <h2 style="margin-top:20px;">Per-Plan Roles</h2>
       <p><?php _e( 'Assign specific WordPress roles to specific subscription plans. Enable this to override the simple active/inactive role mapping.', 'memberful' ); ?></p>
+      <p><?php _e( 'Learn more about roles <a href="https://memberful.com/docs/" target="_blank">here</a>.', 'memberful' ); ?></p>
 
       <table class="form-table">
         <tr>
@@ -73,6 +74,21 @@
                 </td>
               </tr>
               <?php endforeach; ?>
+              <tr>
+                <td class="plan-name">
+                  <strong><?php _e( 'No active subscription plan', 'memberful' ); ?></strong>
+                </td>
+                <td class="mapped-role">
+                  <select name="plan_role_mappings[inactive]">
+                    <option value=""><?php _e( 'No specific role (use default)', 'memberful' ); ?></option>
+                    <?php foreach( $available_roles as $role => $role_name ): ?>
+                    <option value="<?php echo esc_attr( $role ); ?>" <?php echo ( isset($current_mappings['inactive']) && $current_mappings['inactive'] === $role ) ? 'selected="selected"' : '' ?>>
+                      <?php echo esc_html( $role_name ); ?>
+                    </option>
+                    <?php endforeach; ?>
+                  </select>
+                </td>
+              </tr>
             </tbody>
           </table>
         <?php endif; ?>

--- a/wordpress/wp-content/plugins/memberful-wp/views/plan_role_mappings.php
+++ b/wordpress/wp-content/plugins/memberful-wp/views/plan_role_mappings.php
@@ -1,0 +1,80 @@
+<div class="wrap">
+  <?php memberful_wp_render('option_tabs', array('active' => 'plan_role_mappings')); ?>
+  <?php memberful_wp_render('flash'); ?>
+  
+  <h2><?php _e( 'Per-Plan Role Mappings', 'memberful' ); ?></h2>
+  <p><?php _e( 'Assign specific WordPress roles to specific subscription plans. This gives you more granular control over member permissions.', 'memberful' ); ?></p>
+  
+  <form method="post" action="<?php echo esc_url(memberful_wp_plugin_plan_role_mappings_url( TRUE )); ?>">
+    <table class="form-table">
+      <tr>
+        <th scope="row">
+          <label for="use_per_plan_roles"><?php _e( 'Enable Per-Plan Roles', 'memberful' ); ?></label>
+        </th>
+        <td>
+          <input type="checkbox" id="use_per_plan_roles" name="use_per_plan_roles" value="1" <?php checked( $use_per_plan_roles ); ?> />
+          <p class="description"><?php _e( 'When enabled, users will be assigned roles based on their specific subscription plans instead of just active/inactive status.', 'memberful' ); ?></p>
+        </td>
+      </tr>
+    </table>
+
+    <div id="plan-role-mappings" style="<?php echo $use_per_plan_roles ? '' : 'display: none;'; ?>">
+      <h3><?php _e( 'Plan Role Mappings', 'memberful' ); ?></h3>
+      <p><?php _e( 'Map each subscription plan to a WordPress role. Users subscribed to a plan will be assigned the corresponding role.', 'memberful' ); ?></p>
+      
+      <?php if ( empty( $subscription_plans ) ): ?>
+        <p class="description"><?php _e( 'No subscription plans found. Please sync your plans from Memberful first.', 'memberful' ); ?></p>
+      <?php else: ?>
+        <table class="widefat fixed" id="memberful-plan-role-mapping-table">
+          <thead>
+            <tr>
+              <th scope="col" class="manage-column"><?php _e( 'Subscription Plan', 'memberful' ); ?></th>
+              <th scope="col" class="manage-column"><?php _e( 'WordPress Role', 'memberful' ); ?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach( $subscription_plans as $plan_id => $plan ): ?>
+            <tr>
+              <td class="plan-name">
+                <strong><?php echo esc_html( $plan['name'] ); ?></strong>
+                <?php if ( ! empty( $plan['description'] ) ): ?>
+                <br>
+                <small><?php echo esc_html( $plan['description'] ); ?></small>
+                <?php endif; ?>
+              </td>
+              <td class="mapped-role">
+                <select name="plan_role_mappings[<?php echo esc_attr( $plan_id ); ?>]">
+                  <option value=""><?php _e( 'No specific role (use default)', 'memberful' ); ?></option>
+                  <?php foreach( $available_roles as $role => $role_name ): ?>
+                  <option value="<?php echo esc_attr( $role ); ?>" <?php selected( $current_mappings[ $plan_id ], $role ); ?>>
+                    <?php echo esc_html( $role_name ); ?>
+                  </option>
+                  <?php endforeach; ?>
+                </select>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      <?php endif; ?>
+    </div>
+
+    <p class="submit">
+      <input type="submit" name="save_plan_role_mappings" class="button button-primary" value="<?php _e( 'Save Changes', 'memberful' ); ?>" />
+    </p>
+    
+    <?php memberful_wp_nonce_field( 'memberful_options' ); ?>
+  </form>
+
+  <script type="text/javascript">
+  jQuery(document).ready(function($) {
+    $('#use_per_plan_roles').change(function() {
+      if ($(this).is(':checked')) {
+        $('#plan-role-mappings').show();
+      } else {
+        $('#plan-role-mappings').hide();
+      }
+    });
+  });
+  </script>
+</div>


### PR DESCRIPTION
> [!NOTE]
> Introduces per‑plan role mappings with settings UI and role-decision updates, plus ACL exclusivity/fallback tweaks and improved password reset role check.
> 
> - **Roles/Logic**:
>   - Add per‑plan role mappings with storage (`memberful_plan_role_mappings`, `memberful_use_per_plan_roles`) and utilities (`roles.php`).
>   - Update `Memberful_Wp_User_Role_Decision` to assign roles from plan mappings, include fallbacks, capability-based priority, user cache clearing, and new filters.
>   - New helper `memberful_wp_user_role_for_user()` and use it in password‑reset audit.
> - **Admin UI/Settings**:
>   - Extend Advanced Settings to enable per‑plan roles and map plans → roles; optional bulk user role updates on save.
>   - New plan mappings view and URL helper; toggle UI visibility.
> - **ACL/Access**:
>   - Enforce mutual exclusivity between “any subscriber” and specific plan checks in post metabox (UI + save).
>   - Adjust post access logic to only apply “any subscriber” rule when no specific plan/product restrictions exist; otherwise honor intersections.
> - **Hooks/Filters**:
>   - Add filters for allowed roles, per‑plan usage, mappings retrieval, role decisions, and bulk update behavior.