### PR TITLE
MR-33: Add subscription view shortcode

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/src/expiry_banner.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/expiry_banner.php
@@ -60,8 +60,8 @@ function memberful_wp_render_expiry_banner() {
     return;
   }
 
-  $account_url = memberful_account_url();
-  $message = memberful_wp_expiry_banner_message( $expiry_data, $account_url );
+  $renew_url = memberful_subscriptions_url();
+  $message = memberful_wp_expiry_banner_message( $expiry_data, $renew_url );
 
   /**
    * Filters the rendered expiry banner message.
@@ -360,14 +360,14 @@ function memberful_wp_get_soonest_expiring_subscription( $user_id ) {
  * Builds the user-facing banner message.
  *
  * @param array  $expiry_data Expiry information array.
- * @param string $account_url Memberful account URL.
+ * @param string $renew_url   Renewal link URL (the subscriptions section of the member's account).
  *
  * @return string
  */
-function memberful_wp_expiry_banner_message( array $expiry_data, $account_url ) {
+function memberful_wp_expiry_banner_message( array $expiry_data, $renew_url ) {
   $link = wp_sprintf(
     '<a href="%s">%s</a>',
-    esc_url( $account_url ),
+    esc_url( $renew_url ),
     esc_html__( 'Renew now', 'memberful' )
   );
   $expiring_subscriptions_count = max( 1, (int) ( $expiry_data['expiring_subscriptions_count'] ?? 1 ) );

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -62,7 +62,7 @@ function memberful_wp_shortcode_account_link( $atts, $content ) {
 }
 
 function memberful_wp_shortcode_subscriptions_link( $atts, $content ) {
-  return '<a href="'.memberful_subscriptions_url().'" role="subscriptions">'.do_shortcode($content).'</a>';
+  return '<a href="'.esc_url(memberful_subscriptions_url()).'" role="subscriptions">'.do_shortcode($content).'</a>';
 }
 
 function memberful_wp_shortcode_feeds_link( $atts, $content ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/shortcodes.php
@@ -1,6 +1,7 @@
 <?php
 add_shortcode( 'memberful', 'memberful_wp_shortcode' );
 add_shortcode( 'memberful_account_link',  'memberful_wp_shortcode_account_link' );
+add_shortcode( 'memberful_subscriptions_link', 'memberful_wp_shortcode_subscriptions_link' );
 add_shortcode( 'memberful_buy_download_link', 'memberful_wp_shortcode_buy_download_link' );
 add_shortcode( 'memberful_buy_gift_link', 'memberful_wp_shortcode_buy_gift_link' );
 add_shortcode( 'memberful_buy_subscription_link', 'memberful_wp_shortcode_buy_subscription_link' );
@@ -58,6 +59,10 @@ function memberful_wp_shortcode_sign_in_link( $atts, $content ) {
 
 function memberful_wp_shortcode_account_link( $atts, $content ) {
   return '<a href="'.memberful_account_url().'" role="account">'.do_shortcode($content).'</a>';
+}
+
+function memberful_wp_shortcode_subscriptions_link( $atts, $content ) {
+  return '<a href="'.memberful_subscriptions_url().'" role="subscriptions">'.do_shortcode($content).'</a>';
 }
 
 function memberful_wp_shortcode_feeds_link( $atts, $content ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/urls.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/urls.php
@@ -25,6 +25,10 @@ function memberful_account_url( $format = MEMBERFUL_HTML ) {
   return memberful_url( 'account', $format );
 }
 
+function memberful_subscriptions_url( $format = MEMBERFUL_HTML ) {
+  return memberful_url( 'account/subscriptions', $format );
+}
+
 function memberful_registration_page_url() {
   return memberful_url( 'register' );
 }


### PR DESCRIPTION
# Summary

This PR adds a shortcode and URL helper for the subscriptions section of a member's Memberful account, and points the expiry banner's "Renew" link at it so members land directly on their subscriptions instead of the account landing page.

# What's included

- New memberful_subscriptions_url() helper (custom-domain aware) for …/account/subscriptions.
- New [memberful_subscriptions_link] shortcode, mirroring [memberful_account_link].
- Expiry banner: the Renew link now uses memberful_subscriptions_url() instead of memberful_account_url().

# Test plan

- Add [memberful_subscriptions_link]Manage subscriptions[/memberful_subscriptions_link] to a page and confirm it links to …/account/subscriptions (and respects a configured custom domain).
 - Trigger the expiry banner and confirm the Renew now link now lands on the subscriptions section.