### PR TITLE
MR-29: Copy update to gutenberg visibility settings

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/extensions/block-visibility/index.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/extensions/block-visibility/index.js
@@ -95,11 +95,11 @@ const MemberfulVisibilityControlsOptions = (props) => {
           { value: "none", label: __("All users (Default)", "memberful") },
           {
             value: "logged_in",
-            label: __("All logged-in members", "memberful"),
+            label: __("All members (active, inactive, or free)", "memberful"),
           },
           {
             value: "specific",
-            label: __("Specific membership plan", "memberful"),
+            label: __("Members with an active subscription", "memberful"),
           },
         ]}
       />
@@ -149,7 +149,7 @@ const MemberfulVisibilityControls = createHigherOrderComponent((BlockEdit) => {
         {props.isSelected && !excludedBlocks.includes(props.name) && (
           <InspectorControls>
             <PanelBody
-              title={__("Memberful Visibility", "memberful")}
+              title={__("Memberful: Restrict Access", "memberful")}
               initialOpen={false}
             >
               {MemberfulVisibilityControlsOptions(props)}


### PR DESCRIPTION
Update the wording of the visibility settings on the just-released gutenberg update to match what we have in the ad suppression visibility settings as well (which matches the metabox, etc). That way all of the language is consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only i18n label changes in the block editor with no access-control logic modified.
> 
> **Overview**
> Updates **Gutenberg block sidebar** Memberful visibility strings so they match the metabox and ad suppression settings—no behavior or attribute changes.
> 
> The inspector panel title changes from **Memberful Visibility** to **Memberful: Restrict Access**. Dropdown labels are clarified: **logged_in** is now **All members (active, inactive, or free)** (was “All logged-in members”), and **specific** is **Members with an active subscription** (was “Specific membership plan”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9abe189d8e1da132107e68cc840b2c3b5b88fa63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->