### PR TITLE
Fix wp engine issue

### DIFF
--- a/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/metering-countdown/render.php
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/blocks/metering-countdown/render.php
@@ -10,14 +10,33 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
-$post_id = get_queried_object_id();
+$post_id  = get_queried_object_id();
+$template = isset( $attributes['template'] ) ? (string) $attributes['template'] : '';
 
+if ( '' === trim( $template ) ) {
+	return;
+}
+
+if ( Memberful_Metering_Access::RENDER_NONE !== Memberful_Metering_Access::current_anon_mode( $post_id ) ) {
+	printf(
+		'<p %s hidden>%s</p>',
+		get_block_wrapper_attributes(
+			array(
+				'data-memberful-countdown' => '1',
+				'data-memberful-template'  => $template,
+			)
+		),
+		esc_html( str_replace( '{count}', '', $template ) )
+	);
+	return;
+}
+
+// Logged-in / server-known path: render the count directly.
 if ( Memberful_Metering_Access::DECISION_ALLOW_SAMPLE !== Memberful_Metering_Access::get_current_decision( $post_id ) ) {
 	return;
 }
 
-$template = isset( $attributes['template'] ) ? (string) $attributes['template'] : '';
-$message  = str_replace(
+$message = str_replace(
 	'{count}',
 	number_format_i18n( Memberful_Metering_Access::get_current_remaining( $post_id ) ),
 	$template

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/metering.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/metering.js
@@ -1,0 +1,139 @@
+/**
+ * Cache-safe metering runtime.
+ *
+ * The page HTML is a count-agnostic, cacheable default; this script applies the per-visitor decision:
+ *   - free posts are metered entirely client-side via localStorage (no network in the critical path), and
+ *   - protected samples are released only by the uncacheable admin-ajax endpoint, which is the server authority.
+ */
+(() => {
+  const cfg = window.memberfulMetering;
+  if (!cfg || !cfg.postId) {
+    return;
+  }
+
+  const MAX_VIEWS = 100;
+  const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+  const readViews = () => {
+    try {
+      const parsed = JSON.parse(window.localStorage.getItem(cfg.storageKey) || '{}');
+      return parsed && parsed.views && typeof parsed.views === 'object' ? parsed.views : {};
+    } catch (e) {
+      return {};
+    }
+  };
+
+  const prune = (views) => {
+    const cutoff = nowSeconds() - cfg.periodDays * 86400;
+    const kept = {};
+    Object.keys(views).forEach((id) => {
+      if (Number(views[id]) >= cutoff) {
+        kept[id] = Number(views[id]);
+      }
+    });
+    return kept;
+  };
+
+  const persist = (views) => {
+    const ids = Object.keys(views);
+    if (ids.length > MAX_VIEWS) {
+      ids
+        .sort((a, b) => views[a] - views[b])
+        .slice(0, ids.length - MAX_VIEWS)
+        .forEach((id) => delete views[id]);
+    }
+    try {
+      window.localStorage.setItem(cfg.storageKey, JSON.stringify({ v: 1, views }));
+    } catch (e) {
+      // localStorage unavailable (private mode): the meter falls back to the cached HTML state.
+    }
+  };
+
+  const record = (views) => {
+    views[cfg.postId] = nowSeconds();
+    persist(views);
+    return views;
+  };
+
+  const setTripped = () => {
+    document.documentElement.classList.add('memberful-metering-tripped');
+  };
+
+  const hydrateCountdown = (remaining) => {
+    const node = document.querySelector('[data-memberful-countdown]');
+    if (!node) {
+      return;
+    }
+    const template = node.getAttribute('data-memberful-template') || '';
+    node.textContent = template.replace('{count}', String(Math.max(0, remaining)));
+    node.hidden = false;
+  };
+
+  const runFree = () => {
+    if (cfg.limit <= 0) {
+      setTripped();
+      hydrateCountdown(0);
+      return;
+    }
+
+    let views = prune(readViews());
+    const alreadyCounted = Object.prototype.hasOwnProperty.call(views, cfg.postId);
+
+    if (!alreadyCounted && Object.keys(views).length >= cfg.limit) {
+      setTripped();
+      hydrateCountdown(0);
+      return;
+    }
+
+    if (!alreadyCounted) {
+      views = record(views);
+    }
+
+    hydrateCountdown(cfg.limit - Object.keys(views).length);
+  };
+
+  const runProtected = () => {
+    const container = document.querySelector('.memberful-metering');
+
+    const body = new window.URLSearchParams();
+    body.set('action', cfg.action);
+    body.set('post_id', String(cfg.postId));
+
+    window
+      .fetch(cfg.ajaxUrl, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      })
+      .then((response) => response.json())
+      .then((payload) => {
+        const data = payload && payload.success ? payload.data : null;
+        if (!data || !data.released || !container) {
+          return;
+        }
+
+        const content = container.querySelector('.memberful-metering__content');
+        const paywall = container.querySelector('.memberful-metering__paywall');
+        if (content) {
+          content.innerHTML = data.html || '';
+          content.hidden = false;
+        }
+        if (paywall) {
+          paywall.hidden = true;
+        }
+
+        record(prune(readViews()));
+        hydrateCountdown(data.remaining || 0);
+      })
+      .catch(() => {
+        // Endpoint/network failure leaves the cached paywall in place - fail-closed for protected content.
+      });
+  };
+
+  if (cfg.mode === 'free_meter') {
+    runFree();
+  } else if (cfg.mode === 'protected_sample') {
+    runProtected();
+  }
+})();

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/metering.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/metering.js
@@ -50,9 +50,26 @@
   };
 
   const record = (views) => {
-    views[cfg.postId] = nowSeconds();
-    persist(views);
+    if (!Object.prototype.hasOwnProperty.call(views, cfg.postId)) {
+      views[cfg.postId] = nowSeconds();
+      persist(views);
+    }
+
     return views;
+  };
+
+  const endpointPost = (op, keepalive) => {
+    const body = new window.URLSearchParams();
+    body.set('action', cfg.action);
+    body.set('op', op);
+    body.set('post_id', String(cfg.postId));
+    return window.fetch(cfg.ajaxUrl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      keepalive: Boolean(keepalive),
+    });
   };
 
   const setTripped = () => {
@@ -65,7 +82,7 @@
       return;
     }
     const template = node.getAttribute('data-memberful-template') || '';
-    node.textContent = template.replace('{count}', String(Math.max(0, remaining)));
+    node.textContent = template.replace(/\{count\}/g, String(Math.max(0, remaining)));
     node.hidden = false;
   };
 
@@ -87,6 +104,7 @@
 
     if (!alreadyCounted) {
       views = record(views);
+      endpointPost('record', true).catch(() => {});
     }
 
     hydrateCountdown(cfg.limit - Object.keys(views).length);
@@ -95,17 +113,7 @@
   const runProtected = () => {
     const container = document.querySelector('.memberful-metering');
 
-    const body = new window.URLSearchParams();
-    body.set('action', cfg.action);
-    body.set('post_id', String(cfg.postId));
-
-    window
-      .fetch(cfg.ajaxUrl, {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: body.toString(),
-      })
+    endpointPost('sample', false)
       .then((response) => response.json())
       .then((payload) => {
         const data = payload && payload.success ? payload.data : null;

--- a/wordpress/wp-content/plugins/memberful-wp/js/src/metering.js
+++ b/wordpress/wp-content/plugins/memberful-wp/js/src/metering.js
@@ -104,7 +104,6 @@
 
     if (!alreadyCounted) {
       views = record(views);
-      endpointPost('record', true).catch(() => {});
     }
 
     hydrateCountdown(cfg.limit - Object.keys(views).length);

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -98,6 +98,10 @@ function memberful_wp_protect_content( $content ) {
     return memberful_wp_strip_paywall_divider_marker( $content );
   }
 
+  if ( memberful_metering_is_releasing( $post->ID ) ) {
+    return memberful_wp_strip_paywall_divider_marker( $content );
+  }
+
   // Do not filter content for admins
   if ( current_user_can( 'publish_posts' ) ) {
     return memberful_wp_strip_paywall_divider_marker( $content );
@@ -152,6 +156,124 @@ function memberful_wp_protect_content( $content ) {
 }
 
 add_filter( 'memberful_wp_protect_content','wptexturize');
+
+/**
+ * Get or set the post ID whose full body the sample endpoint is currently releasing (0 when idle).
+ *
+ * @param int|null $set New value to set, or null to just read.
+ *
+ * @return int
+ */
+function memberful_metering_releasing_post_id( ?int $set = null ): int {
+  static $current = 0;
+
+  if ( null !== $set ) {
+    $current = $set;
+  }
+
+  return $current;
+}
+
+/**
+ * Whether the gate should release post $post_id in full because the sample endpoint is rendering it.
+ *
+ * @param int $post_id Post ID.
+ *
+ * @return bool
+ */
+function memberful_metering_is_releasing( int $post_id ): bool {
+  return $post_id > 0 && memberful_metering_releasing_post_id() === $post_id;
+}
+
+/**
+ * Wrap the queried post for the anonymous, cache-safe metering runtime. Runs after the gate (priority 100), so a free
+ * body is intact and a protected body is already reduced to teaser+paywall - we only wrap, never re-gate.
+ *
+ * @param string $content Post content as left by the gate.
+ *
+ * @return string
+ */
+function memberful_metering_render_anonymous( $content ) {
+  global $post;
+
+  if ( ! isset( $post ) || doing_filter( 'memberful_wp_protect_content' ) || memberful_metering_releasing_post_id() ) {
+    return $content;
+  }
+
+  if ( (int) $post->ID !== (int) get_queried_object_id() ) {
+    return $content;
+  }
+
+  $mode = Memberful_Metering_Access::current_anon_mode( (int) $post->ID );
+
+  if ( Memberful_Metering_Access::RENDER_FREE_METER === $mode ) {
+    $paywall = apply_filters( 'memberful_wp_protect_content', memberful_marketing_content( $post->ID ) );
+
+    return memberful_metering_wrap_free( memberful_wp_strip_paywall_divider_marker( $content ), $paywall );
+  }
+
+  if ( Memberful_Metering_Access::RENDER_PROTECTED_SAMPLE === $mode ) {
+    return memberful_metering_wrap_protected( $content );
+  }
+
+  return $content;
+}
+add_filter( 'the_content', 'memberful_metering_render_anonymous', 101 );
+
+/**
+ * Markup for a free metered post: full body (visible) plus the paywall (hidden until the client meter trips).
+ *
+ * @param string $body    Full post body.
+ * @param string $paywall Rendered paywall/marketing markup.
+ *
+ * @return string
+ */
+function memberful_metering_wrap_free( string $body, string $paywall ): string {
+  return sprintf(
+    '<div class="memberful-metering" data-memberful-metering="free"><div class="memberful-metering__content">%s</div><div class="memberful-metering__paywall">%s</div></div>',
+    $body,
+    $paywall
+  );
+}
+
+/**
+ * Markup for a protected sample: the teaser+paywall (visible) plus an empty slot the endpoint fills when released.
+ *
+ * @param string $gated Teaser + paywall produced by the gate.
+ *
+ * @return string
+ */
+function memberful_metering_wrap_protected( string $gated ): string {
+  return sprintf(
+    '<div class="memberful-metering" data-memberful-metering="protected"><div class="memberful-metering__paywall">%s</div><div class="memberful-metering__content" hidden></div></div>',
+    $gated
+  );
+}
+
+/**
+ * Render a post's full body for the sample endpoint: released for this post, still gated for any other post embedded
+ * in the content. Removing no filters keeps related/query-loop protection intact (see memberful_metering_is_releasing).
+ *
+ * @param WP_Post $post Post to render.
+ *
+ * @return string
+ */
+function memberful_wp_render_metered_body( WP_Post $post ): string {
+  memberful_metering_releasing_post_id( (int) $post->ID );
+
+  $original        = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+  $GLOBALS['post'] = $post;
+  setup_postdata( $post );
+
+  $html = apply_filters( 'the_content', $post->post_content );
+
+  wp_reset_postdata();
+  $GLOBALS['post'] = $original;
+  memberful_metering_releasing_post_id( 0 );
+
+  return memberful_wp_strip_paywall_divider_marker( $html );
+}
+
 add_filter( 'memberful_wp_protect_content','convert_smilies');
 add_filter( 'memberful_wp_protect_content','convert_chars');
 add_filter( 'memberful_wp_protect_content','wpautop');

--- a/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/content_filter.php
@@ -259,17 +259,19 @@ function memberful_metering_wrap_protected( string $gated ): string {
  * @return string
  */
 function memberful_wp_render_metered_body( WP_Post $post ): string {
-  memberful_metering_releasing_post_id( (int) $post->ID );
+  $original = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 
-  $original        = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+  memberful_metering_releasing_post_id( (int) $post->ID );
   $GLOBALS['post'] = $post;
   setup_postdata( $post );
 
-  $html = apply_filters( 'the_content', $post->post_content );
-
-  wp_reset_postdata();
-  $GLOBALS['post'] = $original;
-  memberful_metering_releasing_post_id( 0 );
+  try {
+    $html = apply_filters( 'the_content', $post->post_content );
+  } finally {
+    wp_reset_postdata();
+    $GLOBALS['post'] = $original;
+    memberful_metering_releasing_post_id( 0 );
+  }
 
   return memberful_wp_strip_paywall_divider_marker( $html );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering.php
@@ -10,9 +10,25 @@ require_once MEMBERFUL_DIR . '/src/metering/sanitizer.php';
 require_once MEMBERFUL_DIR . '/src/metering/storage.php';
 require_once MEMBERFUL_DIR . '/src/metering/access.php';
 require_once MEMBERFUL_DIR . '/src/metering/metabox.php';
+require_once MEMBERFUL_DIR . '/src/metering/sample_endpoint.php';
+require_once MEMBERFUL_DIR . '/src/metering/frontend.php';
 
 Memberful_Metering_Access::register();
 Memberful_Metering_Metabox::register();
+Memberful_Metering_Sample::register();
+
+add_action( 'update_option_' . Memberful_Metering_Config::OPTION_KEY, 'memberful_metering_purge_page_cache' );
+add_action( 'add_option_' . Memberful_Metering_Config::OPTION_KEY, 'memberful_metering_purge_page_cache' );
+
+/**
+ * Cached metered pages embed the limit/period in their runtime config, so a settings change needs a page-cache purge
+ * to take effect before the cache TTL expires.
+ */
+function memberful_metering_purge_page_cache(): void {
+  wp_cache_flush();
+
+  do_action( 'memberful_metering_settings_changed' );
+}
 
 /**
  * Render and save the metering settings screen.

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/access.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/access.php
@@ -316,6 +316,45 @@ class Memberful_Metering_Access {
   }
 
   /**
+   * Record an anonymous free-post view into the signed cookie so protected samples draw from the same allowance.
+   *
+   * The free meter is enforced client-side (localStorage); this only mirrors the view server-side. Validates the post
+   * and that it classifies as a free meter target, then records it, so it can't be used to seed arbitrary post IDs.
+   *
+   * @param int $post_id Post ID from the request.
+   *
+   * @return array{recorded: bool, remaining: int}
+   */
+  public static function record_free_view( int $post_id ): array {
+    $skip = array(
+      'recorded'  => false,
+      'remaining' => 0,
+    );
+
+    $post = get_post( $post_id );
+    if ( ! ( $post instanceof WP_Post ) || 'publish' !== $post->post_status ) {
+      return $skip;
+    }
+
+    if ( ! is_post_publicly_viewable( $post ) || post_password_required( $post ) ) {
+      return $skip;
+    }
+
+    $config = Memberful_Metering_Config::get();
+
+    if ( self::RENDER_FREE_METER !== self::classify_post( $post, 0, $config ) ) {
+      return $skip;
+    }
+
+    $result = self::record_and_check( 0, (int) $post_id, (int) $config['period_days'], (int) $config['anonymous_limit'] );
+
+    return array(
+      'recorded'  => $result['allowed'],
+      'remaining' => $result['remaining'],
+    );
+  }
+
+  /**
    * Store a decision in the per-request cache.
    *
    * @param int    $post_id   Post ID.

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/access.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/access.php
@@ -147,16 +147,21 @@ class Memberful_Metering_Access {
   /**
    * Record a view (when not already counted) and report whether it is allowed plus how many remain in the window.
    *
-   * Shared by the logged-in page path (user meta) and the anonymous sample endpoint (signed cookie).
+   * Shared by the logged-in page path (user meta) and the anonymous sample endpoint (server-side ledger).
    *
-   * @param int $user_id     User ID, or 0 for the anonymous cookie store.
-   * @param int $post_id     Post being viewed.
-   * @param int $period_days Rolling-window length in days.
-   * @param int $limit       Views allowed in the window.
+   * The anonymous read-modify-write is not transactional: a burst of concurrent same-subject requests can each read the
+   * pre-write count and release. That leak is bounded by the sample endpoint's per-IP rate limit and cookieless-release
+   * cap; a fully transactional store belongs to the durable-identity (Pro) tier.
+   *
+   * @param int         $user_id     User ID, or 0 for the anonymous ledger store.
+   * @param int         $post_id     Post being viewed.
+   * @param int         $period_days Rolling-window length in days.
+   * @param int         $limit       Views allowed in the window.
+   * @param string|null $subject     Anonymous subject id; ignored when $user_id is set.
    *
    * @return array{allowed: bool, remaining: int}
    */
-  public static function record_and_check( int $user_id, int $post_id, int $period_days, int $limit ): array {
+  public static function record_and_check( int $user_id, int $post_id, int $period_days, int $limit, ?string $subject = null ): array {
     $limit = max( 0, $limit );
 
     if ( 0 === $limit ) {
@@ -168,7 +173,7 @@ class Memberful_Metering_Access {
 
     $views = $user_id
       ? Memberful_Metering_Storage::read_user_views( $user_id )
-      : Memberful_Metering_Storage::read_anonymous_views();
+      : Memberful_Metering_Storage::read_ledger_views( (string) $subject );
     $views = Memberful_Metering_Storage::prune( $views, $period_days );
 
     $already_counted = isset( $views[ $post_id ] );
@@ -186,7 +191,7 @@ class Memberful_Metering_Access {
       if ( $user_id ) {
         Memberful_Metering_Storage::write_user_views( $user_id, $views );
       } else {
-        Memberful_Metering_Storage::write_anonymous_views( $views, $period_days );
+        Memberful_Metering_Storage::write_ledger_views( (string) $subject, $views, $period_days );
       }
     }
 
@@ -197,11 +202,11 @@ class Memberful_Metering_Access {
   }
 
   /**
-   * Carry anonymous (cookie) views over to the user's meta on login, then drop the anonymous cookie.
+   * Carry anonymous (ledger) views over to the user's meta on login, then drop the anonymous subject and its ledger.
    *
-   * Clearing the cookie means a later logout, or a silently expired auth session, falls back to a fresh anonymous
-   * cookie (0 views used). This is an accepted soft-meter limitation. Closing it would need a server-side anonymous
-   * identity, which is deferred to v2 as per the MR-5 requirements.
+   * The anonymous meter lives in a server-side ledger keyed by an opaque subject cookie; clearing that cookie (or a
+   * logout) starts a fresh subject with 0 views. Raising the cost of that reset further — a device-bound identity — is
+   * the Pro/v2 direction (see the subject-key filter in Memberful_Metering_Storage).
    *
    * @param string  $user_login The user's login.
    * @param WP_User $user       The user object.
@@ -209,9 +214,13 @@ class Memberful_Metering_Access {
   public static function on_wp_login( string $user_login, WP_User $user ): void {
     unset( $user_login );
 
-    $anonymous_views = Memberful_Metering_Storage::read_anonymous_views();
+    $subject         = Memberful_Metering_Storage::current_subject();
+    $anonymous_views = ( null !== $subject )
+      ? Memberful_Metering_Storage::read_ledger_views( $subject )
+      : array();
+
     if ( empty( $anonymous_views ) ) {
-      Memberful_Metering_Storage::clear_anonymous_cookie();
+      Memberful_Metering_Storage::clear_subject();
       return;
     }
 
@@ -227,7 +236,7 @@ class Memberful_Metering_Access {
     $merged = Memberful_Metering_Storage::prune( $merged, $period_days );
 
     Memberful_Metering_Storage::write_user_views( $user->ID, $merged );
-    Memberful_Metering_Storage::clear_anonymous_cookie();
+    Memberful_Metering_Storage::clear_subject();
   }
 
   /**
@@ -277,10 +286,54 @@ class Memberful_Metering_Access {
   }
 
   /**
+   * Whether a post is a protected sample that MAY be released to an anonymous visitor, checked with NO side effect (no
+   * subject minted, no view recorded). Lets the endpoint reject ineligible posts and charge the cookieless cap before
+   * evaluate_sample() mints a cookie or records a view. Only a published, publicly viewable, password-free post that
+   * classifies as a protected sample qualifies.
+   *
+   * @param int $post_id Post ID from the request.
+   *
+   * @return bool
+   */
+  public static function is_releasable_sample( int $post_id ): bool {
+    $post = get_post( $post_id );
+    if ( ! ( $post instanceof WP_Post ) || 'publish' !== $post->post_status ) {
+      return false;
+    }
+
+    if ( ! is_post_publicly_viewable( $post ) || post_password_required( $post ) ) {
+      return false;
+    }
+
+    return self::RENDER_PROTECTED_SAMPLE === self::classify_post( $post, 0, Memberful_Metering_Config::get() );
+  }
+
+  /**
+   * Whether a subject currently holds an active (non-stale) allowance in its ledger. The endpoint uses this for
+   * cap-exemption: a cookie whose ledger is empty, expired, or cleared is NOT a returning visitor for cap purposes —
+   * it is a fresh allowance and must be charged the cookieless cap, so a replayed/reset cookie cannot dodge it.
+   *
+   * @param string|null $subject Resolved subject id, or null.
+   *
+   * @return bool
+   */
+  public static function subject_has_active_views( ?string $subject ): bool {
+    if ( null === $subject || '' === $subject ) {
+      return false;
+    }
+
+    $period = (int) Memberful_Metering_Config::get()['period_days'];
+    $views  = Memberful_Metering_Storage::prune( Memberful_Metering_Storage::read_ledger_views( $subject ), $period );
+
+    return ! empty( $views );
+  }
+
+  /**
    * Server-authoritative decision for the sample endpoint: may an anonymous visitor read this protected post now?
    *
-   * Re-validates the post and re-classifies it (never trusting the client) before recording against the signed
-   * cookie. Only a published, publicly viewable, password-free post that classifies as a protected sample can release.
+   * Re-validates and re-classifies the post (never trusting the client), then mints the subject and records the view
+   * against the ledger. Has side effects (subject mint, ledger write); callers that must gate BEFORE those side effects
+   * (e.g. the cookieless cap) should consult is_releasable_sample() first.
    *
    * @param int $post_id Post ID from the request.
    *
@@ -307,49 +360,12 @@ class Memberful_Metering_Access {
       return $deny;
     }
 
-    $result = self::record_and_check( 0, (int) $post_id, (int) $config['period_days'], (int) $config['anonymous_limit'] );
+    $subject = Memberful_Metering_Storage::get_or_create_subject( (int) $config['period_days'] );
+
+    $result = self::record_and_check( 0, (int) $post_id, (int) $config['period_days'], (int) $config['anonymous_limit'], $subject );
 
     return array(
       'released'  => $result['allowed'],
-      'remaining' => $result['remaining'],
-    );
-  }
-
-  /**
-   * Record an anonymous free-post view into the signed cookie so protected samples draw from the same allowance.
-   *
-   * The free meter is enforced client-side (localStorage); this only mirrors the view server-side. Validates the post
-   * and that it classifies as a free meter target, then records it, so it can't be used to seed arbitrary post IDs.
-   *
-   * @param int $post_id Post ID from the request.
-   *
-   * @return array{recorded: bool, remaining: int}
-   */
-  public static function record_free_view( int $post_id ): array {
-    $skip = array(
-      'recorded'  => false,
-      'remaining' => 0,
-    );
-
-    $post = get_post( $post_id );
-    if ( ! ( $post instanceof WP_Post ) || 'publish' !== $post->post_status ) {
-      return $skip;
-    }
-
-    if ( ! is_post_publicly_viewable( $post ) || post_password_required( $post ) ) {
-      return $skip;
-    }
-
-    $config = Memberful_Metering_Config::get();
-
-    if ( self::RENDER_FREE_METER !== self::classify_post( $post, 0, $config ) ) {
-      return $skip;
-    }
-
-    $result = self::record_and_check( 0, (int) $post_id, (int) $config['period_days'], (int) $config['anonymous_limit'] );
-
-    return array(
-      'recorded'  => $result['allowed'],
       'remaining' => $result['remaining'],
     );
   }

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/access.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/access.php
@@ -13,12 +13,26 @@ class Memberful_Metering_Access {
   const DECISION_ALLOW_SAMPLE = 'allow_sample';
   const DECISION_TRIP_METER   = 'trip_meter';
 
+  const RENDER_NONE             = 'none';
+  const RENDER_FREE_METER       = 'free_meter';
+  const RENDER_PROTECTED_SAMPLE = 'protected_sample';
+
   /**
    * Per-request decision cache keyed by post ID.
    *
    * @var array<int, array{decision: string, remaining: int}>
    */
   private static $decisions = array();
+
+  /**
+   * Anonymous render mode for the singular post under view (one per request), for the render/enqueue layer.
+   *
+   * @var array{post_id: int, mode: string}
+   */
+  private static $anon_render = array(
+    'post_id' => 0,
+    'mode'    => self::RENDER_NONE,
+  );
 
   /**
    * Register hooks. Called once from src/metering.php.
@@ -29,7 +43,12 @@ class Memberful_Metering_Access {
   }
 
   /**
-   * Compute and cache the metering decision for the singular post under view.
+   * Compute the metering outcome for the singular post under view.
+   *
+   * Logged-in visitors are decided server-side here (their page is never edge-cached). Anonymous visitors only get a
+   * count-agnostic render mode cached for the render layer; their per-visitor enforcement happens client-side
+   * (localStorage, free posts) or via the uncacheable sample endpoint (protected posts), so the page stays cacheable
+   * even on hosts that strip cookies before PHP.
    */
   public static function on_template_redirect(): void {
     if ( ! self::is_metered_request() ) {
@@ -46,29 +65,63 @@ class Memberful_Metering_Access {
       return;
     }
 
-    if ( get_post_meta( $post->ID, 'memberful_metering_exempt', true ) ) {
-      self::cache( $post->ID, self::DECISION_IGNORE );
+    $user_id = get_current_user_id();
+    $mode    = self::classify_post( $post, $user_id, $config );
+
+    if ( self::RENDER_NONE === $mode ) {
       return;
     }
 
-    $exclude_rules = $config['exclude_rules'];
+    if ( $user_id ) {
+      $result = self::record_and_check( $user_id, $post->ID, (int) $config['period_days'], (int) $config['registered_limit'] );
+
+      self::emit_no_cache_headers();
+      self::cache(
+        $post->ID,
+        $result['allowed'] ? self::DECISION_ALLOW_SAMPLE : self::DECISION_TRIP_METER,
+        $result['remaining']
+      );
+      return;
+    }
+
+    self::$anon_render = array(
+      'post_id' => (int) $post->ID,
+      'mode'    => $mode,
+    );
+  }
+
+  /**
+   * Classify a post for metering independent of any view count, so the result is identical for every anonymous
+   * visitor and safe to cache.
+   *
+   * @param WP_Post $post    Post under consideration.
+   * @param int     $user_id Current user ID (0 for anonymous).
+   * @param array   $config  Sanitised metering config.
+   *
+   * @return string One of the RENDER_* constants.
+   */
+  public static function classify_post( WP_Post $post, int $user_id, array $config ): string {
+    if ( empty( $config['enabled'] ) || empty( $config['rules'] ) ) {
+      return self::RENDER_NONE;
+    }
+
+    if ( get_post_meta( $post->ID, 'memberful_metering_exempt', true ) ) {
+      return self::RENDER_NONE;
+    }
 
     if (
       ! self::post_matches_any_group( $post, $config['rules'] )
-      || self::post_matches_any_group( $post, $exclude_rules )
+      || self::post_matches_any_group( $post, $config['exclude_rules'] )
     ) {
-      self::cache( $post->ID, self::DECISION_IGNORE );
-      return;
+      return self::RENDER_NONE;
     }
 
-    $user_id  = get_current_user_id();
     $has_paid = $user_id && (
       ! empty( memberful_wp_user_plans_subscribed_to( $user_id ) )
       || ! empty( memberful_wp_user_downloads( $user_id ) )
     );
     if ( $has_paid ) {
-      self::cache( $post->ID, self::DECISION_IGNORE );
-      return;
+      return self::RENDER_NONE;
     }
 
     $post_is_protected = ! memberful_can_user_access_post( 0, $post->ID );
@@ -76,41 +129,59 @@ class Memberful_Metering_Access {
     if ( $post_is_protected ) {
       // Visitors already entitled to the post read it in full and are never metered.
       if ( $user_id && memberful_can_user_access_post( $user_id, $post->ID ) ) {
-        self::cache( $post->ID, self::DECISION_IGNORE );
-        return;
+        return self::RENDER_NONE;
       }
 
-      // Otherwise the post only enters the meter when the publisher opted in.
+      // Otherwise the post only enters the meter when the publisher opted in; by default the existing hard paywall
+      // handles it.
       if ( empty( $config['apply_to_protected_posts'] ) ) {
-        self::cache( $post->ID, self::DECISION_IGNORE );
-        return;
+        return self::RENDER_NONE;
       }
+
+      return self::RENDER_PROTECTED_SAMPLE;
     }
 
-    $period_days = (int) $config['period_days'];
-    $limit       = max( 0, $user_id ? (int) $config['registered_limit'] : (int) $config['anonymous_limit'] );
+    return self::RENDER_FREE_METER;
+  }
+
+  /**
+   * Record a view (when not already counted) and report whether it is allowed plus how many remain in the window.
+   *
+   * Shared by the logged-in page path (user meta) and the anonymous sample endpoint (signed cookie).
+   *
+   * @param int $user_id     User ID, or 0 for the anonymous cookie store.
+   * @param int $post_id     Post being viewed.
+   * @param int $period_days Rolling-window length in days.
+   * @param int $limit       Views allowed in the window.
+   *
+   * @return array{allowed: bool, remaining: int}
+   */
+  public static function record_and_check( int $user_id, int $post_id, int $period_days, int $limit ): array {
+    $limit = max( 0, $limit );
 
     if ( 0 === $limit ) {
-      self::emit_no_cache_headers();
-      self::cache( $post->ID, self::DECISION_TRIP_METER, 0 );
-      return;
+      return array(
+        'allowed'   => false,
+        'remaining' => 0,
+      );
     }
 
-    $views       = $user_id
+    $views = $user_id
       ? Memberful_Metering_Storage::read_user_views( $user_id )
       : Memberful_Metering_Storage::read_anonymous_views();
-    $views       = Memberful_Metering_Storage::prune( $views, $period_days );
+    $views = Memberful_Metering_Storage::prune( $views, $period_days );
 
-    $already_counted = isset( $views[ $post->ID ] );
+    $already_counted = isset( $views[ $post_id ] );
 
     if ( ! $already_counted && count( $views ) >= $limit ) {
-      self::emit_no_cache_headers();
-      self::cache( $post->ID, self::DECISION_TRIP_METER, 0 );
-      return;
+      return array(
+        'allowed'   => false,
+        'remaining' => 0,
+      );
     }
 
     if ( ! $already_counted ) {
-      $views[ $post->ID ] = time();
+      $views[ $post_id ] = time();
 
       if ( $user_id ) {
         Memberful_Metering_Storage::write_user_views( $user_id, $views );
@@ -119,8 +190,10 @@ class Memberful_Metering_Access {
       }
     }
 
-    self::emit_no_cache_headers();
-    self::cache( $post->ID, self::DECISION_ALLOW_SAMPLE, max( 0, $limit - count( $views ) ) );
+    return array(
+      'allowed'   => true,
+      'remaining' => max( 0, $limit - count( $views ) ),
+    );
   }
 
   /**
@@ -181,6 +254,65 @@ class Memberful_Metering_Access {
     return isset( self::$decisions[ $post_id ]['remaining'] )
       ? (int) self::$decisions[ $post_id ]['remaining']
       : 0;
+  }
+
+  /**
+   * The anonymous render mode cached for a post in this request, or RENDER_NONE.
+   *
+   * @param int $post_id Post ID.
+   *
+   * @return string
+   */
+  public static function current_anon_mode( int $post_id ): string {
+    return self::$anon_render['post_id'] === $post_id ? self::$anon_render['mode'] : self::RENDER_NONE;
+  }
+
+  /**
+   * Whether the singular post under view is an anonymous metered view (free or protected-sample).
+   *
+   * @return bool
+   */
+  public static function is_anon_metered_view(): bool {
+    return self::RENDER_NONE !== self::current_anon_mode( (int) get_queried_object_id() );
+  }
+
+  /**
+   * Server-authoritative decision for the sample endpoint: may an anonymous visitor read this protected post now?
+   *
+   * Re-validates the post and re-classifies it (never trusting the client) before recording against the signed
+   * cookie. Only a published, publicly viewable, password-free post that classifies as a protected sample can release.
+   *
+   * @param int $post_id Post ID from the request.
+   *
+   * @return array{released: bool, remaining: int}
+   */
+  public static function evaluate_sample( int $post_id ): array {
+    $deny = array(
+      'released'  => false,
+      'remaining' => 0,
+    );
+
+    $post = get_post( $post_id );
+    if ( ! ( $post instanceof WP_Post ) || 'publish' !== $post->post_status ) {
+      return $deny;
+    }
+
+    if ( ! is_post_publicly_viewable( $post ) || post_password_required( $post ) ) {
+      return $deny;
+    }
+
+    $config = Memberful_Metering_Config::get();
+
+    if ( self::RENDER_PROTECTED_SAMPLE !== self::classify_post( $post, 0, $config ) ) {
+      return $deny;
+    }
+
+    $result = self::record_and_check( 0, (int) $post_id, (int) $config['period_days'], (int) $config['anonymous_limit'] );
+
+    return array(
+      'released'  => $result['allowed'],
+      'remaining' => $result['remaining'],
+    );
   }
 
   /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/frontend.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/frontend.php
@@ -38,9 +38,14 @@ function memberful_metering_enqueue_frontend(): void {
     true
   );
 
+  $runtime_config = wp_json_encode( memberful_metering_runtime_config(), JSON_HEX_TAG );
+  if ( false === $runtime_config ) {
+    return;
+  }
+
   wp_add_inline_script(
     'memberful-metering',
-    'window.memberfulMetering = ' . wp_json_encode( memberful_metering_runtime_config(), JSON_HEX_TAG ) . ';',
+    'window.memberfulMetering = ' . $runtime_config . ';',
     'before'
   );
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/frontend.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/frontend.php
@@ -38,7 +38,11 @@ function memberful_metering_enqueue_frontend(): void {
     true
   );
 
-  wp_localize_script( 'memberful-metering', 'memberfulMetering', memberful_metering_runtime_config() );
+  wp_add_inline_script(
+    'memberful-metering',
+    'window.memberfulMetering = ' . wp_json_encode( memberful_metering_runtime_config(), JSON_HEX_TAG ) . ';',
+    'before'
+  );
 }
 
 /**

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/frontend.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/frontend.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Front-end metering runtime: enqueues the cache-safe script and styles for anonymous metered post views, and prints
+ * a pre-paint guard so a free post that is already over the limit hides its body before first paint (no flash).
+ *
+ * @package memberful-wp
+ */
+
+add_action( 'wp_enqueue_scripts', 'memberful_metering_enqueue_frontend' );
+add_action( 'wp_head', 'memberful_metering_prepaint', 1 );
+
+/**
+ * Enqueue the runtime + styles with per-URL-static config only (no per-visitor data, so the page stays cacheable).
+ */
+function memberful_metering_enqueue_frontend(): void {
+  if ( ! Memberful_Metering_Access::is_anon_metered_view() ) {
+    return;
+  }
+
+  wp_enqueue_style(
+    'memberful-metering',
+    MEMBERFUL_URL . '/stylesheets/metering.css',
+    array(),
+    MEMBERFUL_VERSION
+  );
+
+  $asset = MEMBERFUL_DIR . '/js/build/metering.asset.php';
+  $info  = file_exists( $asset ) ? require $asset : array(
+    'dependencies' => array(),
+    'version'      => MEMBERFUL_VERSION,
+  );
+
+  wp_enqueue_script(
+    'memberful-metering',
+    MEMBERFUL_URL . '/js/build/metering.js',
+    $info['dependencies'],
+    $info['version'],
+    true
+  );
+
+  wp_localize_script( 'memberful-metering', 'memberfulMetering', memberful_metering_runtime_config() );
+}
+
+/**
+ * For a free metered post, mark the document (before paint) when localStorage already shows the meter tripped, so CSS
+ * can hide the body without a flash. The snippet is identical for every anonymous visitor, so it stays cacheable.
+ */
+function memberful_metering_prepaint(): void {
+  if ( Memberful_Metering_Access::RENDER_FREE_METER !== Memberful_Metering_Access::current_anon_mode( (int) get_queried_object_id() ) ) {
+    return;
+  }
+
+  $config = wp_json_encode( memberful_metering_runtime_config(), JSON_HEX_TAG );
+  if ( false === $config ) {
+    return;
+  }
+
+  // Read-only mirror of the free-meter "already over the limit?" check; metering.js (footer) does the authoritative
+  // metering. JSON_HEX_TAG keeps the injected config safe inside the script tag.
+  $script = sprintf(
+    '( function ( config ) {
+  try {
+    var data = JSON.parse( window.localStorage.getItem( config.storageKey ) || "{}" ) || {};
+    var views = data.views || {};
+    var cutoff = Math.floor( Date.now() / 1000 ) - config.periodDays * 86400;
+    var count = 0;
+    var alreadyCounted = false;
+
+    Object.keys( views ).forEach( function ( postId ) {
+      if ( views[ postId ] >= cutoff ) {
+        count++;
+        if ( Number( postId ) === config.postId ) {
+          alreadyCounted = true;
+        }
+      }
+    } );
+
+    if ( ! alreadyCounted && count >= config.limit ) {
+      document.documentElement.className += " memberful-metering-tripped";
+    }
+  } catch ( error ) {}
+}( %s ) );',
+    $config
+  );
+
+  wp_print_inline_script_tag( $script );
+}
+
+/**
+ * Per-URL-static runtime config shared by the enqueued script and the pre-paint guard.
+ *
+ * @return array
+ */
+function memberful_metering_runtime_config(): array {
+  $config  = Memberful_Metering_Config::get();
+  $post_id = (int) get_queried_object_id();
+
+  return array_merge(
+    array(
+      'postId'     => $post_id,
+      'mode'       => Memberful_Metering_Access::current_anon_mode( $post_id ),
+      'limit'      => (int) $config['anonymous_limit'],
+      'periodDays' => (int) $config['period_days'],
+      'storageKey' => Memberful_Metering_Storage::COOKIE_NAME,
+    ),
+    Memberful_Metering_Sample::script_args()
+  );
+}

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/sample_endpoint.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/sample_endpoint.php
@@ -34,6 +34,18 @@ class Memberful_Metering_Sample {
       wp_send_json_error( array( 'code' => 'bad_request' ), 400 );
     }
 
+    // Free posts mirror their view here so protected samples share the same allowance; they need no body back.
+    if ( 'record' === filter_input( INPUT_POST, 'op' ) ) {
+      $recorded = Memberful_Metering_Access::record_free_view( $post_id );
+
+      wp_send_json_success(
+        array(
+          'recorded'  => ! empty( $recorded['recorded'] ),
+          'remaining' => (int) $recorded['remaining'],
+        )
+      );
+    }
+
     $result = Memberful_Metering_Access::evaluate_sample( $post_id );
 
     if ( empty( $result['released'] ) ) {

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/sample_endpoint.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/sample_endpoint.php
@@ -1,8 +1,11 @@
 <?php
 /**
  * Uncacheable admin-ajax endpoint that releases a protected post's body to an anonymous visitor who is still within
- * their free allowance. admin-ajax is never edge-cached and still receives cookies, so the signed meter cookie works
- * here even on hosts that strip it from cacheable page views.
+ * their free allowance. admin-ajax is never edge-cached and still receives cookies, so the server-issued subject cookie
+ * and its ledger work here even on hosts that strip cookies from cacheable page views.
+ *
+ * Release is decided server-side against the subject's ledger (never the client's self-reported count), the request is
+ * limited to same-origin callers, and both per-IP and site-wide rate limits bound scripted enumeration/drain attempts.
  *
  * @package memberful-wp
  */
@@ -14,6 +17,31 @@ class Memberful_Metering_Sample {
   const ACTION = 'memberful_metering_sample';
 
   /**
+   * The sole allowed value of the `op` request field.
+   */
+  const OPS = array( 'sample' );
+
+  /**
+   * Max endpoint calls per client IP per minute before returning 429.
+   */
+  const RATE_PER_IP = 30;
+
+  /**
+   * Max endpoint calls site-wide per minute before returning 429 (botnet circuit-breaker).
+   */
+  const RATE_GLOBAL = 600;
+
+  /**
+   * Max protected-body releases per client IP per hour for requests that arrive WITHOUT a valid subject cookie.
+   *
+   * A genuine reader is cookieless only on their first request (the response then sets the cookie); a scraper that
+   * drops or rotates cookies is cookieless on every request. Capping cookieless releases therefore bounds catalogue
+   * drain to roughly this many bodies per IP per hour while barely touching real visitors — including shared/CGNAT
+   * IPs, where each real person still spends only one cookieless request. Filterable; 0 disables the cap.
+   */
+  const COOKIELESS_RELEASE_CAP = 20;
+
+  /**
    * Register the logged-out handler only. Logged-in visitors bypass the cache and are decided on the page path.
    */
   public static function register(): void {
@@ -21,27 +49,60 @@ class Memberful_Metering_Sample {
   }
 
   /**
-   * Decide server-side (against the signed cookie) whether to release the post body, and return it when allowed.
+   * Decide server-side (against the subject ledger) whether to release the post body, and return it when allowed.
    *
-   * No nonce: a page-embedded nonce goes stale in cache, and a forged request can at most advance the caller's own
-   * meter and receive content already bounded server-side by the anonymous limit. The response is same-origin JSON.
+   * No nonce: a page-embedded nonce goes stale in cache. CSRF is mitigated by the same-origin check. Drain resistance
+   * is layered: a cookie-bearing caller is capped by its own server-side ledger (anonymous_limit distinct posts); a
+   * cookieless caller (a fresh ledger every request) is additionally capped per-IP (COOKIELESS_RELEASE_CAP) and by the
+   * per-IP/global rate limits. This BOUNDS scripted extraction rather than eliminating it — a device-durable identity
+   * (the Pro tier, via the subject-key filter) is what fully closes it. Responses are same-origin JSON.
    */
   public static function handle(): void {
     nocache_headers();
+
+    if ( self::is_cross_origin() ) {
+      wp_send_json_error( array( 'code' => 'forbidden' ), 403 );
+    }
+
+    $op = (string) filter_input( INPUT_POST, 'op' );
+    if ( ! in_array( $op, self::OPS, true ) ) {
+      wp_send_json_error( array( 'code' => 'bad_request' ), 400 );
+    }
 
     $post_id = (int) filter_input( INPUT_POST, 'post_id', FILTER_SANITIZE_NUMBER_INT );
     if ( $post_id <= 0 ) {
       wp_send_json_error( array( 'code' => 'bad_request' ), 400 );
     }
 
-    // Free posts mirror their view here so protected samples share the same allowance; they need no body back.
-    if ( 'record' === filter_input( INPUT_POST, 'op' ) ) {
-      $recorded = Memberful_Metering_Access::record_free_view( $post_id );
+    if ( self::is_rate_limited() ) {
+      wp_send_json_error( array( 'code' => 'rate_limited' ), 429 );
+    }
 
+    // Gate eligibility and the cookieless cap BEFORE evaluate_sample(), which has side effects (it
+    // mints the subject cookie and records the view). Order matters:
+    //   1. is_releasable_sample() is a pure check — ineligible posts are rejected without charging the cap.
+    //   2. A caller WITHOUT an active ledger is the drain vector — a fresh visitor, or a replayed/reset/expired cookie
+    //      whose ledger is empty. Cap-exemption keys off holding an active ledger, NOT merely presenting a cookie, so
+    //      a replayed cookie cannot dodge the cap. If over the per-IP hourly cap we deny HERE, before any cookie is
+    //      minted or view recorded — nothing for the caller to keep and retry with.
+    // cookieless_over_cap() increments atomically, so concurrent such releases cannot all slip under the cap.
+    if ( ! Memberful_Metering_Access::is_releasable_sample( $post_id ) ) {
       wp_send_json_success(
         array(
-          'recorded'  => ! empty( $recorded['recorded'] ),
-          'remaining' => (int) $recorded['remaining'],
+          'released'  => false,
+          'remaining' => 0,
+        )
+      );
+    }
+
+    $subject    = Memberful_Metering_Storage::current_subject();
+    $has_ledger = Memberful_Metering_Access::subject_has_active_views( $subject );
+
+    if ( ! $has_ledger && self::cookieless_over_cap() ) {
+      wp_send_json_success(
+        array(
+          'released'  => false,
+          'remaining' => 0,
         )
       );
     }
@@ -76,5 +137,93 @@ class Memberful_Metering_Sample {
       'ajaxUrl' => admin_url( 'admin-ajax.php' ),
       'action'  => self::ACTION,
     );
+  }
+
+  /**
+   * Whether the request carries an Origin/Referer that is present and does NOT match this site. A missing header is
+   * not treated as cross-origin (some browsers/privacy modes omit it); the rate limits and ledger cover that case.
+   *
+   * @return bool
+   */
+  private static function is_cross_origin(): bool {
+    $source = '';
+    if ( ! empty( $_SERVER['HTTP_ORIGIN'] ) ) {
+      $source = (string) wp_unslash( $_SERVER['HTTP_ORIGIN'] );
+    } elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
+      $source = (string) wp_unslash( $_SERVER['HTTP_REFERER'] );
+    }
+
+    if ( '' === $source ) {
+      return false;
+    }
+
+    $source_host = wp_parse_url( $source, PHP_URL_HOST );
+    $site_host   = wp_parse_url( home_url(), PHP_URL_HOST );
+
+    if ( ! is_string( $source_host ) || ! is_string( $site_host ) ) {
+      return true;
+    }
+
+    return strtolower( $source_host ) !== strtolower( $site_host );
+  }
+
+  /**
+   * Coarse per-IP and site-wide rate limiting via transient counters. Bounds scripted enumeration/drain of the
+   * protected catalogue independently of the per-subject ledger cap.
+   *
+   * @return bool True when the caller should be rejected with 429.
+   */
+  private static function is_rate_limited(): bool {
+    $ip_key     = 'mbf_mtr_rl_' . hash( 'sha256', self::client_ip() . wp_salt( 'auth' ) );
+    $global_key = 'mbf_mtr_rl_global';
+
+    // Increment first, then compare the returned value: concurrent requests get distinct atomic counts, so they cannot
+    // all observe an under-limit value and slip through. Over-limit requests still increment, which keeps them blocked.
+    $ip_hits     = Memberful_Metering_Storage::incr_counter( $ip_key, MINUTE_IN_SECONDS );
+    $global_hits = Memberful_Metering_Storage::incr_counter( $global_key, MINUTE_IN_SECONDS );
+
+    return ( $ip_hits > self::RATE_PER_IP || $global_hits > self::RATE_GLOBAL );
+  }
+
+  /**
+   * The caller's IP from REMOTE_ADDR (the only source not attacker-spoofable without proxy access), validated.
+   *
+   * @return string
+   */
+  private static function client_ip(): string {
+    $ip = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '';
+
+    return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '0.0.0.0';
+  }
+
+  /**
+   * Atomically count this cookieless request against the client IP's hourly quota and report whether the quota is now
+   * exceeded. Incrementing as part of the check (rather than checking, then incrementing only after release) means
+   * concurrent cookieless requests get distinct counts and cannot all slip under the cap.
+   *
+   * @return bool
+   */
+  private static function cookieless_over_cap(): bool {
+    /**
+     * Filter the per-IP hourly cap on cookieless protected-body releases. Return 0 to disable the cap.
+     *
+     * @param int $cap Default COOKIELESS_RELEASE_CAP.
+     */
+    $cap = (int) apply_filters( 'memberful_metering_cookieless_release_cap', self::COOKIELESS_RELEASE_CAP );
+
+    if ( $cap <= 0 ) {
+      return false;
+    }
+
+    return Memberful_Metering_Storage::incr_counter( self::cookieless_key(), HOUR_IN_SECONDS ) > $cap;
+  }
+
+  /**
+   * Transient key for the per-IP cookieless-release counter (IP hashed with a site salt).
+   *
+   * @return string
+   */
+  private static function cookieless_key(): string {
+    return 'mbf_mtr_cl_' . hash( 'sha256', self::client_ip() . wp_salt( 'auth' ) );
   }
 }

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/sample_endpoint.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/sample_endpoint.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Uncacheable admin-ajax endpoint that releases a protected post's body to an anonymous visitor who is still within
+ * their free allowance. admin-ajax is never edge-cached and still receives cookies, so the signed meter cookie works
+ * here even on hosts that strip it from cacheable page views.
+ *
+ * @package memberful-wp
+ */
+
+/**
+ * Class Memberful_Metering_Sample.
+ */
+class Memberful_Metering_Sample {
+  const ACTION = 'memberful_metering_sample';
+
+  /**
+   * Register the logged-out handler only. Logged-in visitors bypass the cache and are decided on the page path.
+   */
+  public static function register(): void {
+    add_action( 'wp_ajax_nopriv_' . self::ACTION, array( __CLASS__, 'handle' ) );
+  }
+
+  /**
+   * Decide server-side (against the signed cookie) whether to release the post body, and return it when allowed.
+   *
+   * No nonce: a page-embedded nonce goes stale in cache, and a forged request can at most advance the caller's own
+   * meter and receive content already bounded server-side by the anonymous limit. The response is same-origin JSON.
+   */
+  public static function handle(): void {
+    nocache_headers();
+
+    $post_id = (int) filter_input( INPUT_POST, 'post_id', FILTER_SANITIZE_NUMBER_INT );
+    if ( $post_id <= 0 ) {
+      wp_send_json_error( array( 'code' => 'bad_request' ), 400 );
+    }
+
+    $result = Memberful_Metering_Access::evaluate_sample( $post_id );
+
+    if ( empty( $result['released'] ) ) {
+      wp_send_json_success(
+        array(
+          'released'  => false,
+          'remaining' => 0,
+        )
+      );
+    }
+
+    wp_send_json_success(
+      array(
+        'released'  => true,
+        'remaining' => (int) $result['remaining'],
+        'html'      => memberful_wp_render_metered_body( get_post( $post_id ) ),
+      )
+    );
+  }
+
+  /**
+   * AJAX args passed to the front-end runtime via wp_localize_script.
+   *
+   * @return array
+   */
+  public static function script_args(): array {
+    return array(
+      'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+      'action'  => self::ACTION,
+    );
+  }
+}

--- a/wordpress/wp-content/plugins/memberful-wp/src/metering/storage.php
+++ b/wordpress/wp-content/plugins/memberful-wp/src/metering/storage.php
@@ -1,6 +1,14 @@
 <?php
 /**
- * Metering storage: signed cookie for anonymous views, user meta for logged-in.
+ * Metering storage.
+ *
+ * Anonymous visitors are identified by an opaque, server-issued subject id carried in a signed, HttpOnly cookie; their
+ * view counts live in a server-side transient ledger keyed by a hash of that subject. The cookie is only a pointer to
+ * server state, never the state itself, so deleting or replaying it cannot rewind the meter to an attacker's advantage
+ * (a fresh cookie yields a fresh, empty ledger, which the sample endpoint's cookieless-release cap and rate limiting
+ * bound). Logged-in visitors
+ * use user meta. The subject is minted only in uncached contexts (the admin-ajax sample endpoint, or login), never on a
+ * cacheable page — so the anonymous page stays byte-identical and cacheable on hosts that strip cookies before PHP.
  *
  * @package memberful-wp
  */
@@ -13,61 +21,136 @@ class Memberful_Metering_Storage {
   const USER_META_KEY = 'memberful_metering_views';
 
   /**
-   * Cookies over 4 KB are dropped by the browser.
-   *
-   * The size is roughly MAX_VIEWS x 20 bytes of JSON, then base64 + HMAC.
-   * At 100 stored entries after base64 + HMAC, the size is ~ 2 KB, at 150 it's ~ 4 KB.
+   * Transient key prefix for the server-side anonymous ledger.
+   */
+  const LEDGER_PREFIX = 'mbf_mtr_l_';
+
+  /**
+   * Object-cache group for atomic rate-limit counters (used only when a persistent object cache is available).
+   */
+  const CACHE_GROUP = 'memberful_metering';
+
+  /**
+   * Bytes of entropy in the opaque subject id (128-bit → 32 hex chars).
+   */
+  const SUBJECT_BYTES = 16;
+
+  /**
+   * Upper bound on stored view entries per subject/user. The ledger is server-side, so this only guards runaway meta;
+   * it is far above any realistic rolling-window count.
    */
   const MAX_VIEWS = 100;
 
   /**
-   * Read and verify the anonymous views cookie.
+   * Read and validate the opaque subject id from the request cookie without minting a new one.
    *
-   * @return array<int, int> Map of post_id => unix timestamp. Empty on missing/invalid cookie.
+   * Safe to call in any context (does not send headers).
+   *
+   * @return string|null The subject id, or null when absent/invalid.
    */
-  public static function read_anonymous_views(): array {
+  public static function read_subject(): ?string {
     if ( empty( $_COOKIE[ self::COOKIE_NAME ] ) ) {
-      return array();
+      return null;
     }
 
     $cookie = wp_unslash( $_COOKIE[ self::COOKIE_NAME ] );
     if ( ! is_string( $cookie ) ) {
-      return array();
+      return null;
     }
 
-    $payload = self::verify( $cookie );
-    if ( empty( $payload['views'] ) || ! is_array( $payload['views'] ) ) {
-      return array();
-    }
-
-    return self::normalize_views( $payload['views'] );
+    return self::verify_subject( $cookie );
   }
 
   /**
-   * Sign and write the anonymous views cookie.
+   * Return the subject id for this request, minting and setting the cookie when absent.
    *
-   * @param array<int, int> $views       Map of post_id => unix timestamp.
-   * @param int             $period_days Rolling-window length in days; also drives cookie expiry.
+   * MUST be called only from an uncached context (admin-ajax, login) — never while rendering a cacheable page, or the
+   * Set-Cookie would either be dropped by the cache or baked into shared HTML.
+   *
+   * @param int $period_days Rolling-window length; also drives the cookie's expiry.
+   *
+   * @return string
    */
-  public static function write_anonymous_views( array $views, int $period_days ): void {
-    $views   = self::cap( $views );
-    $expires = time() + ( $period_days * DAY_IN_SECONDS );
+  public static function get_or_create_subject( int $period_days ): string {
+    $subject = self::read_subject();
 
-    $payload = wp_json_encode(
-      array(
-        'v'     => 1,
-        'views' => $views,
-        'exp'   => $expires,
-      )
-    );
+    if ( null === $subject ) {
+      $subject = bin2hex( random_bytes( self::SUBJECT_BYTES ) );
+      $expires = time() + ( max( 1, $period_days ) * DAY_IN_SECONDS );
+      $signed  = self::sign( $subject, $expires );
 
-    if ( false === $payload ) {
+      self::send_cookie( $signed, $expires );
+      $_COOKIE[ self::COOKIE_NAME ] = $signed;
+    }
+
+    return self::apply_subject_filter( $subject );
+  }
+
+  /**
+   * Read the resolved subject (the raw cookie id passed through the identity filter) without minting. Returns null when
+   * no valid subject cookie is present.
+   *
+   * @return string|null
+   */
+  public static function current_subject(): ?string {
+    $raw = self::read_subject();
+
+    return ( null === $raw ) ? null : self::apply_subject_filter( $raw );
+  }
+
+  /**
+   * Pass the raw cookie subject through the durable-identity filter (the Fingerprint/Pro seam) so minting, metering,
+   * the login merge, and clearing all key the ledger by the same value.
+   *
+   * @param string $raw Raw opaque cookie subject.
+   *
+   * @return string
+   */
+  private static function apply_subject_filter( string $raw ): string {
+    /**
+     * Filter the anonymous subject key. This is the seam for a durable-identity provider (e.g. a Fingerprint
+     * visitorId) that replaces the opaque-cookie id with a device-attested one without changing the transport.
+     *
+     * @param string $raw The opaque, cookie-backed subject id.
+     */
+    $override = apply_filters( 'memberful_metering_subject_key', $raw );
+
+    return ( is_string( $override ) && '' !== $override ) ? $override : $raw;
+  }
+
+  /**
+   * Read a subject's metering views from the server-side ledger.
+   *
+   * @param string $subject Subject id.
+   *
+   * @return array<int, int> Map of post_id => unix timestamp.
+   */
+  public static function read_ledger_views( string $subject ): array {
+    if ( '' === $subject ) {
+      return array();
+    }
+
+    $raw = get_transient( self::ledger_key( $subject ) );
+    if ( ! is_array( $raw ) ) {
+      return array();
+    }
+
+    return self::normalize_views( $raw );
+  }
+
+  /**
+   * Persist a subject's metering views to the server-side ledger.
+   *
+   * @param string          $subject     Subject id.
+   * @param array<int, int> $views       Map of post_id => unix timestamp.
+   * @param int             $period_days Rolling-window length; also the transient TTL.
+   */
+  public static function write_ledger_views( string $subject, array $views, int $period_days ): void {
+    if ( '' === $subject ) {
       return;
     }
 
-    $cookie = self::sign( $payload );
-    self::send_cookie( $cookie, $expires );
-    $_COOKIE[ self::COOKIE_NAME ] = $cookie;
+    set_transient( self::ledger_key( $subject ), self::cap( $views ), max( 1, $period_days ) * DAY_IN_SECONDS );
   }
 
   /**
@@ -97,11 +180,46 @@ class Memberful_Metering_Storage {
   }
 
   /**
-   * Clear the anonymous views cookie (e.g. after merging into user meta on login).
+   * Drop a subject's ledger and clear its cookie (e.g. after merging into user meta on login).
    */
-  public static function clear_anonymous_cookie(): void {
+  public static function clear_subject(): void {
+    $subject = self::current_subject();
+    if ( null !== $subject ) {
+      delete_transient( self::ledger_key( $subject ) );
+    }
+
     self::send_cookie( '', time() - 3600 );
     unset( $_COOKIE[ self::COOKIE_NAME ] );
+  }
+
+  /**
+   * Atomically increment a fixed-window counter and return the new value. Atomic on a persistent object cache;
+   * degrades to a best-effort transient counter (approximate under high concurrency) where none is present.
+   *
+   * @param string $key Counter key.
+   * @param int    $ttl Window length in seconds.
+   *
+   * @return int
+   */
+  public static function incr_counter( string $key, int $ttl ): int {
+    if ( wp_using_ext_object_cache() ) {
+      wp_cache_add( $key, 0, self::CACHE_GROUP, $ttl );
+      $new = wp_cache_incr( $key, 1, self::CACHE_GROUP );
+      if ( is_int( $new ) ) {
+        return $new;
+      }
+      // Object cache present but without a working incr: fall through to the transient counter. A given backend is
+      // consistent about incr support, so reads and writes stay on one store (read_counter no longer exists to split
+      // them). This never returns a constant that would disable enforcement.
+    }
+
+    // Transient counter: atomic where transients are backed by a persistent object cache; best-effort (approximate
+    // under heavy concurrency) on hosts with no object cache, where WordPress exposes no atomic increment primitive.
+    // Acceptable for a soft meter — the per-subject ledger cap still bounds each individual visitor regardless.
+    $value = (int) get_transient( $key ) + 1;
+    set_transient( $key, $value, $ttl );
+
+    return $value;
   }
 
   /**
@@ -124,55 +242,63 @@ class Memberful_Metering_Storage {
   }
 
   /**
-   * Sign a payload string and return the full cookie value (payload.signature).
+   * The transient key for a subject's ledger. The subject is hashed with a site salt so the stored key never reveals
+   * the cookie value.
    *
-   * @param string $payload JSON payload.
+   * @param string $subject Subject id.
    *
    * @return string
    */
-  private static function sign( string $payload ): string {
-    $payload_b64 = self::b64url_encode( $payload );
-    $signature   = hash_hmac( 'sha256', $payload_b64, wp_salt( 'auth' ), true );
-
-    return $payload_b64 . '.' . self::b64url_encode( $signature );
+  private static function ledger_key( string $subject ): string {
+    return self::LEDGER_PREFIX . hash( 'sha256', $subject . wp_salt( 'auth' ) );
   }
 
   /**
-   * Verify a signed cookie and return the decoded payload, or [] on any failure.
+   * Sign a subject id with an embedded expiry and return "subject.exp.signature".
+   *
+   * @param string $subject Opaque subject id.
+   * @param int    $expires Unix timestamp after which the token is invalid.
+   *
+   * @return string
+   */
+  private static function sign( string $subject, int $expires ): string {
+    $payload   = $subject . '.' . $expires;
+    $signature = hash_hmac( 'sha256', $payload, wp_salt( 'auth' ), true );
+
+    return $payload . '.' . self::b64url_encode( $signature );
+  }
+
+  /**
+   * Verify a signed subject cookie and return the subject id, or null on any failure.
    *
    * @param string $cookie Raw cookie value.
    *
-   * @return array
+   * @return string|null
    */
-  private static function verify( string $cookie ): array {
-    $parts = explode( '.', $cookie, 2 );
-    if ( 2 !== count( $parts ) ) {
-      return array();
+  private static function verify_subject( string $cookie ): ?string {
+    $parts = explode( '.', $cookie );
+    if ( 3 !== count( $parts ) ) {
+      return null;
     }
 
-    list( $payload_b64, $signature_b64 ) = $parts;
+    list( $subject, $expires, $signature_b64 ) = $parts;
 
-    $expected = self::b64url_encode( hash_hmac( 'sha256', $payload_b64, wp_salt( 'auth' ), true ) );
+    if ( ! preg_match( '/^[a-f0-9]{' . ( self::SUBJECT_BYTES * 2 ) . '}$/', $subject ) ) {
+      return null;
+    }
+
+    // Reject an expired token: past its embedded expiry it is treated as no cookie, so the caller falls back to the
+    // cookieless path and its per-IP cap. This stops a retained cookie being replayed indefinitely.
+    if ( ! ctype_digit( $expires ) || (int) $expires < time() ) {
+      return null;
+    }
+
+    $expected = self::b64url_encode( hash_hmac( 'sha256', $subject . '.' . $expires, wp_salt( 'auth' ), true ) );
     if ( ! hash_equals( $expected, $signature_b64 ) ) {
-      return array();
+      return null;
     }
 
-    $payload = self::b64url_decode( $payload_b64 );
-    if ( false === $payload ) {
-      return array();
-    }
-
-    $decoded = json_decode( $payload, true );
-    if ( ! is_array( $decoded ) ) {
-      return array();
-    }
-
-    // Reject a cookie past its stored expiry. prune()'s rolling window is the real enforcement.
-    if ( isset( $decoded['exp'] ) && (int) $decoded['exp'] < time() ) {
-      return array();
-    }
-
-    return $decoded;
+    return $subject;
   }
 
   /**
@@ -215,7 +341,7 @@ class Memberful_Metering_Storage {
   }
 
   /**
-   * Set the metering cookie with the project's standard attributes.
+   * Set the metering (subject) cookie with the project's standard attributes.
    *
    * @param string $value   Cookie value.
    * @param int    $expires Unix timestamp for cookie expiry.
@@ -244,16 +370,5 @@ class Memberful_Metering_Storage {
    */
   private static function b64url_encode( string $bytes ): string {
     return rtrim( strtr( base64_encode( $bytes ), '+/', '-_' ), '=' );
-  }
-
-  /**
-   * URL-safe base64 decode.
-   *
-   * @param string $value Encoded value.
-   *
-   * @return string|false
-   */
-  private static function b64url_decode( string $value ) {
-    return base64_decode( strtr( $value, '-_', '+/' ) );
   }
 }

--- a/wordpress/wp-content/plugins/memberful-wp/stylesheets/metering.css
+++ b/wordpress/wp-content/plugins/memberful-wp/stylesheets/metering.css
@@ -1,0 +1,18 @@
+/* ---------------------------------------------------------
+Metering runtime (cache-safe front-end gate)
+
+Free posts keep their body in the cached HTML and toggle to the paywall client-side once the meter trips. Protected
+samples ship only the paywall; the body slot stays hidden via the `hidden` attribute until the endpoint releases it.
+Visual paywall styling lives in paywall.css.
+------------------------------------------------------------ */
+.memberful-metering[data-memberful-metering="free"] .memberful-metering__paywall {
+  display: none;
+}
+
+html.memberful-metering-tripped .memberful-metering[data-memberful-metering="free"] .memberful-metering__content {
+  display: none;
+}
+
+html.memberful-metering-tripped .memberful-metering[data-memberful-metering="free"] .memberful-metering__paywall {
+  display: block;
+}

--- a/wordpress/wp-content/plugins/memberful-wp/webpack.config.js
+++ b/wordpress/wp-content/plugins/memberful-wp/webpack.config.js
@@ -7,5 +7,6 @@ module.exports = {
     "editor-scripts": "./js/src/editor-scripts.js",
     "paywall-builder": "./js/src/paywall-builder.js",
     "metering-admin": "./js/src/metering-admin.js",
+    "metering": "./js/src/metering.js",
   },
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes how paywalled and metered content is shown to anonymous users (client enforcement, AJAX body injection, and new abuse limits), which directly affects access control and publisher revenue on cached hosts.
> 
> **Overview**
> Makes **anonymous** metered article HTML the same for every visitor so full-page caches (e.g. WP Engine) stay valid, while logged-in users still get server-side decisions and no-cache behavior.
> 
> **Free metered posts** ship full content plus a hidden paywall wrapper; `metering.js` enforces the rolling limit in **localStorage**, toggles paywall via CSS, and hydrates the countdown block. A small **pre-paint** head script avoids flashing content when the meter is already tripped.
> 
> **Protected sample posts** ship only teaser + paywall; an uncacheable **`admin-ajax`** handler decides release from a **server-side ledger** keyed by a signed subject cookie (minted only on that endpoint), with same-origin checks, rate limits, and a cookieless per-IP release cap. Released HTML is rendered via a dedicated “releasing” path on `the_content`.
> 
> Anonymous storage moves from **HMAC cookie payloads of view counts** to **opaque subject cookie + transient ledger**; login still merges ledger views into user meta. Metering settings changes trigger **`wp_cache_flush`** and a hook so embedded limits in cached pages can refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75213373263329356576c6eeea95194309b52791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->